### PR TITLE
Enforce device budget in scheduler

### DIFF
--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,7 +1,15 @@
 import unittest
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
 import main
 
+
 class TestScheduler(unittest.TestCase):
+    def setUp(self):
+        main.Reporter._metrics = {}
+
     def test_scheduler_records_metrics(self):
         device = main.MemoryDevice('VRAM', 512)
         ops = [
@@ -13,6 +21,14 @@ class TestScheduler(unittest.TestCase):
         self.assertEqual(duration, 2)
         self.assertEqual(main.Reporter.report('VRAM_used'), 0)
         self.assertEqual(main.Reporter.report('makespan'), 2)
+
+    def test_budget_overrun_records_metric(self):
+        device = main.MemoryDevice('VRAM', 512, budget=256)
+        ops = [main.Operation('op1', 300, 1, device)]
+        scheduler = main.Scheduler(device)
+        with self.assertRaises(main.DeviceBudgetExceeded):
+            scheduler.run(ops)
+        self.assertEqual(main.Reporter.report('budget_exceeded'), 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- track budget, used, and reserved memory in `MemoryDevice`
- raise `DeviceBudgetExceeded` when allocations exceed budget
- log `budget_exceeded` metrics in `Scheduler`
- add tests for budget overrun metrics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfcefae50c8327a8cae513ba171d53