### PR TITLE
Add memory eviction policies and tests

### DIFF
--- a/tests/test_eviction_policy.py
+++ b/tests/test_eviction_policy.py
@@ -1,0 +1,32 @@
+import unittest
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+import main
+
+
+class TestEvictionPolicies(unittest.TestCase):
+    def setUp(self):
+        main.Reporter._metrics = {}
+
+    def test_drop_policy_evicts_and_counts(self):
+        device = main.MemoryDevice('VRAM', 100)
+        device.allocate(80)
+        with self.assertRaises(main.DeviceCapacityExceeded):
+            device.allocate(50)
+        self.assertEqual(device.used, 30)
+        self.assertEqual(main.Reporter.report('evictions'), 1)
+
+    def test_remap_policy_moves_and_counts(self):
+        device = main.MemoryDevice('VRAM', 100, eviction_policy=main.RemapPolicy)
+        device.allocate(80)
+        with self.assertRaises(main.DeviceCapacityExceeded):
+            device.allocate(50)
+        self.assertEqual(device.used, 30)
+        self.assertEqual(device.reserved, 50)
+        self.assertEqual(main.Reporter.report('remaps'), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- introduce EvictionPolicy base with DropPolicy and RemapPolicy implementations
- add optional eviction_policy to MemoryDevice and handle capacity overflows
- cover eviction and remap behavior with dedicated unit tests

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bfcff65c7083279d51f40e0d6bbaec