### PR TITLE
Add parallel device scheduler with per-device metrics

### DIFF
--- a/tests/test_eviction_policy.py
+++ b/tests/test_eviction_policy.py
@@ -15,6 +15,7 @@ class TestEvictionPolicies(unittest.TestCase):
         device.allocate(80)
         with self.assertRaises(main.DeviceCapacityExceeded):
             device.allocate(50)
+        print('Drop metrics:', main.Reporter.report(['VRAM_used', 'evictions']))
         self.assertEqual(device.used, 30)
         self.assertEqual(main.Reporter.report('evictions'), 1)
 
@@ -23,6 +24,7 @@ class TestEvictionPolicies(unittest.TestCase):
         device.allocate(80)
         with self.assertRaises(main.DeviceCapacityExceeded):
             device.allocate(50)
+        print('Remap metrics:', main.Reporter.report(['VRAM_used', 'VRAM_reserved', 'remaps']))
         self.assertEqual(device.used, 30)
         self.assertEqual(device.reserved, 50)
         self.assertEqual(main.Reporter.report('remaps'), 1)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -13,22 +13,39 @@ class TestScheduler(unittest.TestCase):
     def test_scheduler_records_metrics(self):
         device = main.MemoryDevice('VRAM', 512)
         ops = [
-            main.Operation('op1', 128, 1, device),
-            main.Operation('op2', 128, 1, device),
+            main.Operation('op1', 128, 1, 'VRAM'),
+            main.Operation('op2', 128, 1, 'VRAM'),
         ]
-        scheduler = main.Scheduler(device)
+        scheduler = main.Scheduler([device])
         duration = scheduler.run(ops)
+        print('Sequential metrics:', main.Reporter.report(['VRAM_used', 'makespan', 'VRAM_idle_time']))
         self.assertEqual(duration, 2)
         self.assertEqual(main.Reporter.report('VRAM_used'), 0)
         self.assertEqual(main.Reporter.report('makespan'), 2)
 
     def test_budget_overrun_records_metric(self):
         device = main.MemoryDevice('VRAM', 512, budget=256)
-        ops = [main.Operation('op1', 300, 1, device)]
-        scheduler = main.Scheduler(device)
+        ops = [main.Operation('op1', 300, 1, 'VRAM')]
+        scheduler = main.Scheduler([device])
         with self.assertRaises(main.DeviceBudgetExceeded):
             scheduler.run(ops)
+        print('Budget metric:', main.Reporter.report('budget_exceeded'))
         self.assertEqual(main.Reporter.report('budget_exceeded'), 1)
+
+    def test_parallel_execution_reduces_makespan(self):
+        gpu = main.MemoryDevice('GPU', 512)
+        cpu = main.MemoryDevice('CPU', 512)
+        ops = [
+            main.Operation('gpu_op', 128, 4, 'GPU'),
+            main.Operation('cpu_op', 128, 4, 'CPU'),
+        ]
+        scheduler = main.Scheduler([gpu, cpu])
+        duration = scheduler.run_parallel(ops)
+        print('Parallel metrics:', main.Reporter.report(['makespan', 'GPU_idle_time', 'CPU_idle_time']))
+        self.assertEqual(duration, 4)
+        self.assertEqual(main.Reporter.report('GPU_idle_time'), 0)
+        self.assertEqual(main.Reporter.report('CPU_idle_time'), 0)
+        self.assertEqual(main.Reporter.report('makespan'), 4)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- allow operations to target multiple devices and allocate per-device memory
- schedule operations concurrently across devices with idle time metrics
- verify parallel execution reduces makespan and records device timelines

## Testing
- `python -m pytest -s`


------
https://chatgpt.com/codex/tasks/task_e_68bfd138a6188327a65bbb3d864613e2