### PR TITLE
Implement block-based memory management with compaction metrics

### DIFF
--- a/tests/test_fragmentation.py
+++ b/tests/test_fragmentation.py
@@ -1,0 +1,36 @@
+import unittest
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+import main
+
+
+class TestFragmentation(unittest.TestCase):
+    def setUp(self):
+        main.Reporter._metrics = {}
+
+    def test_compaction_reduces_fragmentation(self):
+        device = main.MemoryDevice('VRAM', 100)
+        device.allocate(30)
+        device.allocate(30)
+        device.free(30)
+        device.allocate(10)
+        device.allocate(10)
+        device.free(10)
+        device.free(10)
+        before = main.Reporter.report(['VRAM_fragmentation_ratio', 'VRAM_largest_free_block'])
+        print('Before compaction:', before)
+        with self.assertRaises(main.DeviceCapacityExceeded):
+            device.allocate(50)
+        self.assertEqual(main.Reporter.report('allocation_failures'), 1)
+        device.compact()
+        after = main.Reporter.report(['VRAM_fragmentation_ratio', 'VRAM_largest_free_block'])
+        print('After compaction:', after)
+        self.assertLess(after[0], before[0])
+        device.allocate(50)
+        self.assertEqual(main.Reporter.report('allocation_failures'), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `MemoryBlock` abstraction and track allocations via block list
- implement block-based `MemoryDevice` with fragmentation metrics and compaction
- test fragmentation scenarios ensuring compaction reduces fragmentation

## Testing
- `python -m pytest tests/test_eviction_policy.py tests/test_scheduler.py tests/test_fragmentation.py -s`

------
https://chatgpt.com/codex/tasks/task_e_68bfd22bc6888327bca11734af49e61b