### PR TITLE
Handle arbitrary free order in memory device

### DIFF
--- a/tests/test_fragmentation.py
+++ b/tests/test_fragmentation.py
@@ -12,13 +12,13 @@ class TestFragmentation(unittest.TestCase):
 
     def test_compaction_reduces_fragmentation(self):
         device = main.MemoryDevice('VRAM', 100)
-        device.allocate(30)
-        device.allocate(30)
-        device.free(30)
-        device.allocate(10)
-        device.allocate(10)
-        device.free(10)
-        device.free(10)
+        b1 = device.allocate(30)
+        b2 = device.allocate(30)
+        device.free(b2)
+        b3 = device.allocate(10)
+        b4 = device.allocate(10)
+        device.free(b4)
+        device.free(b3)
         before = main.Reporter.report(['VRAM_fragmentation_ratio', 'VRAM_largest_free_block'])
         print('Before compaction:', before)
         with self.assertRaises(main.DeviceCapacityExceeded):

--- a/tests/test_free_order.py
+++ b/tests/test_free_order.py
@@ -1,0 +1,30 @@
+import unittest
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+import main
+
+
+class TestFreeOrder(unittest.TestCase):
+    def setUp(self):
+        main.Reporter._metrics = {}
+
+    def test_free_non_lifo(self):
+        device = main.MemoryDevice('VRAM', 100)
+        a = device.allocate(30)
+        b = device.allocate(20)
+        c = device.allocate(10)
+        start_b = b.start
+        device.free(b)
+        d = device.allocate(15)
+        print('Blocks after reuse:', device.blocks)
+        self.assertEqual(d.start, start_b)
+        self.assertIn(a, device.allocations)
+        self.assertIn(c, device.allocations)
+        self.assertIn(d, device.allocations)
+        self.assertEqual(device.used, 55)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- track allocation blocks and free by handle instead of LIFO
- add internal helper to evict a specific amount and update eviction policies
- cover non-LIFO freeing in tests

## Testing
- `pytest tests/test_capacity_guard.py tests/test_eviction_policy.py tests/test_fragmentation.py tests/test_scheduler.py tests/test_free_order.py`

------
https://chatgpt.com/codex/tasks/task_e_68bfd690a5f08327a803bcb6a152d597