### PR TITLE
Preserve full torch device identifiers when registering tensors

### DIFF
--- a/main.py
+++ b/main.py
@@ -325,7 +325,9 @@ class TensorLoadBalancer(Scheduler):
             dev_key = getattr(tensor, 'device_type', None)
         if dev_key is None:
             raise AttributeError('Tensor device not specified')
-        if not isinstance(dev_key, str):
+        if isinstance(dev_key, torch.device):
+            dev_key = str(dev_key)
+        elif not isinstance(dev_key, str):
             dev_key = getattr(dev_key, 'type', dev_key)
         device = self.devices[dev_key] if isinstance(dev_key, str) else dev_key
         block = device.allocate(size)

--- a/tests/test_tensor_devices.py
+++ b/tests/test_tensor_devices.py
@@ -1,0 +1,29 @@
+import unittest
+import sys
+import pathlib
+import torch
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+import main
+
+
+class DummyTensor:
+    def __init__(self, size, device):
+        self.nbytes = size
+        self.device = device
+
+
+class TestTensorLoadBalancerDevice(unittest.TestCase):
+    def setUp(self):
+        main.Reporter._metrics = {}
+
+    def test_preserves_full_device_identifier(self):
+        devices = [main.MemoryDevice('cuda:0', 100), main.MemoryDevice('cuda:1', 100)]
+        balancer = main.TensorLoadBalancer(devices)
+        tensor = DummyTensor(10, torch.device('cuda:1'))
+        balancer.register(tensor)
+        self.assertTrue(balancer.isRegistered(tensor))
+        registered_device = balancer._registry[id(tensor)]['device']
+        print('Registered tensors:', main.Reporter.report('registered_tensors'))
+        self.assertEqual(registered_device.name, 'cuda:1')
+        balancer.unregister(tensor)


### PR DESCRIPTION
## Summary
- Preserve full `torch.device` strings in `TensorLoadBalancer.register` to avoid collapsing GPU indices
- Add regression test ensuring multi-GPU device keys are handled correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfe55645a8832797dd4fcaafcad67f