### PR TITLE
feat: add tokenizer state

### DIFF
--- a/poted/core.py
+++ b/poted/core.py
@@ -1,0 +1,72 @@
+class ByteAlphabet:
+    def __init__(self):
+        self._symbols = []
+        for i in range(256):
+            self._symbols.append(i)
+
+    def contains(self, byte):
+        return isinstance(byte, int) and 0 <= byte < 256
+
+
+class Token(int):
+    def __new__(cls, value):
+        if not isinstance(value, int) or value < 0:
+            raise ValueError('Token value must be non-negative integer')
+        return int.__new__(cls, value)
+
+    def __repr__(self):
+        return 'Token(%d)' % int(self)
+
+
+class Dictionary:
+    def __init__(self, reporter):
+        self._b2t = {}
+        self._t2b = {}
+        self._next = 0
+        self._reporter = reporter
+        self._update_metrics()
+
+    def _update_metrics(self):
+        if self._reporter:
+            self._reporter.report('dictionary_size', 'Number of entries in tokenizer dictionary', self.size)
+
+    @property
+    def size(self):
+        return len(self._b2t)
+
+    def add(self, byte):
+        token = self._b2t.get(byte)
+        if token is None:
+            token = Token(self._next)
+            self._b2t[byte] = token
+            self._t2b[int(token)] = byte
+            self._next += 1
+            self._update_metrics()
+        return token
+
+    def token(self, byte):
+        return self._b2t.get(byte)
+
+    def byte(self, token):
+        return self._t2b.get(int(token))
+
+
+class TokenizerState:
+    def __init__(self, reporter):
+        self._alphabet = ByteAlphabet()
+        self._dictionary = Dictionary(reporter)
+
+    def encode_byte(self, byte):
+        if not self._alphabet.contains(byte):
+            raise ValueError('Byte out of alphabet')
+        return self._dictionary.add(byte)
+
+    def decode_token(self, token):
+        byte = self._dictionary.byte(token)
+        if byte is None:
+            raise KeyError('Unknown token')
+        return byte
+
+    @property
+    def dictionary(self):
+        return self._dictionary

--- a/tests/test_poted_core.py
+++ b/tests/test_poted_core.py
@@ -1,0 +1,37 @@
+import unittest
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+import main
+from poted.core import TokenizerState
+
+
+class TestTokenizerState(unittest.TestCase):
+    def setUp(self):
+        main.Reporter._metrics = {}
+
+    def test_encode_decode_bijection(self):
+        state = TokenizerState(main.Reporter)
+        for b in range(256):
+            token = state.encode_byte(b)
+            decoded = state.decode_token(token)
+            self.assertEqual(decoded, b)
+        size = main.Reporter.report('dictionary_size')
+        print('Dictionary size after encoding:', size)
+        self.assertEqual(size, 256)
+
+    def test_decode_encode_bijection(self):
+        state = TokenizerState(main.Reporter)
+        tokens = [state.encode_byte(b) for b in range(256)]
+        for token in tokens:
+            byte = state.decode_token(token)
+            token2 = state.encode_byte(byte)
+            self.assertEqual(int(token2), int(token))
+        unique_tokens = len({int(t) for t in tokens})
+        print('Unique tokens:', unique_tokens)
+        self.assertEqual(unique_tokens, 256)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add encapsulated tokenizer classes for bytes and tokens
- track dictionary size via Reporter metrics
- test bijective encoding/decoding of bytes and tokens

## Testing
- `pytest tests/test_poted_core.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfea475ee48327becf6efa91432671