### PR TITLE
Implement streaming tokenizer with adaptive dictionary

### DIFF
--- a/poted/tokenizer.py
+++ b/poted/tokenizer.py
@@ -1,0 +1,84 @@
+class StreamingTokenizer:
+    def __init__(self, reporter=None, max_word_length=16):
+        from .core import ByteAlphabet, Token  # import inside to respect style
+        self._alphabet = ByteAlphabet()
+        self._reporter = reporter
+        self._max_word_length = max_word_length
+        self._dict = {}
+        self._rev_dict = {}
+        self._next = 0
+        self._longest = 1
+        for i in range(256):
+            token = Token(self._next)
+            self._dict[(i,)] = token
+            self._rev_dict[int(token)] = (i,)
+            self._next += 1
+        if self._reporter:
+            self._reporter.report(
+                'dictionary_size',
+                'Number of entries in tokenizer dictionary',
+                self._next,
+            )
+            self._reporter.report(
+                'longest_match',
+                'Length of longest match during tokenization',
+                self._longest,
+            )
+
+    def _add_sequence(self, seq):
+        if len(seq) > self._max_word_length or seq in self._dict:
+            return
+        from .core import Token
+        token = Token(self._next)
+        self._dict[seq] = token
+        self._rev_dict[int(token)] = seq
+        self._next += 1
+        if self._reporter:
+            self._reporter.report('dictionary_size', value=self._next)
+
+    def _update_longest(self, length):
+        if length > self._longest:
+            self._longest = length
+            if self._reporter:
+                self._reporter.report('longest_match', value=length)
+
+    def encode(self, data):
+        if isinstance(data, bytes):
+            data = list(data)
+        if not data:
+            return []
+        for b in data:
+            if not self._alphabet.contains(b):
+                raise ValueError('Byte out of alphabet')
+        result = []
+        w = (data[0],)
+        for b in data[1:]:
+            c = (b,)
+            if len(w) < self._max_word_length and w + c in self._dict:
+                w = w + c
+            else:
+                result.append(self._dict[w])
+                self._update_longest(len(w))
+                if len(w) < self._max_word_length:
+                    self._add_sequence(w + c)
+                w = c
+        result.append(self._dict[w])
+        self._update_longest(len(w))
+        return result
+
+    def decode(self, tokens):
+        if not tokens:
+            return []
+        result = []
+        prev = self._rev_dict.get(int(tokens[0]))
+        if prev is None:
+            raise KeyError('Unknown token')
+        result.extend(prev)
+        for t in tokens[1:]:
+            seq = self._rev_dict.get(int(t))
+            if seq is None:
+                seq = prev + (prev[0],)
+            result.extend(seq)
+            self._add_sequence(prev + (seq[0],))
+            prev = seq
+        return result

--- a/tests/test_streaming_tokenizer.py
+++ b/tests/test_streaming_tokenizer.py
@@ -1,0 +1,45 @@
+import unittest
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+import main
+from poted.tokenizer import StreamingTokenizer
+
+
+class TestStreamingTokenizer(unittest.TestCase):
+    def setUp(self):
+        main.Reporter._metrics = {}
+
+    def test_roundtrip(self):
+        tokenizer = StreamingTokenizer(main.Reporter, max_word_length=8)
+        stream = [65, 66, 65, 66, 65, 66, 65, 66]
+        tokens = tokenizer.encode(stream)
+        decoded = tokenizer.decode(tokens)
+        print('Encoded tokens:', tokens)
+        print('Decoded stream:', decoded)
+        print('Metrics:', main.Reporter._metrics)
+        self.assertEqual(decoded, stream)
+
+    def test_longest_match_metric(self):
+        tokenizer = StreamingTokenizer(main.Reporter, max_word_length=10)
+        stream = [65] * 6
+        tokenizer.encode(stream)
+        longest = main.Reporter.report('longest_match')
+        print('Longest match metric:', longest)
+        self.assertEqual(longest, 3)
+
+    def test_word_length_limit(self):
+        tokenizer = StreamingTokenizer(main.Reporter, max_word_length=2)
+        stream = [65, 65, 65, 65]
+        tokenizer.encode(stream)
+        size = main.Reporter.report('dictionary_size')
+        longest = main.Reporter.report('longest_match')
+        print('Dictionary size:', size)
+        print('Longest match:', longest)
+        self.assertEqual(size, 257)
+        self.assertEqual(longest, 2)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `StreamingTokenizer` with on-the-fly dictionary expansion and longest-match encoding
- track `longest_match` metric and respect maximum word length
- cover streaming tokenizer with round-trip and metric tests

## Testing
- `python -m unittest tests.test_streaming_tokenizer -v`
- `python -m unittest tests.test_poted_core -v`


------
https://chatgpt.com/codex/tasks/task_e_68bfeb3d3ef88327bb455f023466e4b9