### PR TITLE
Implement PoTED pipeline with tokenizer integration and roundtrip test

### DIFF
--- a/poted/pipeline.py
+++ b/poted/pipeline.py
@@ -1,0 +1,47 @@
+class JsonSerializer:
+    def serialize(self, obj):
+        import json
+        data = json.dumps(obj, separators=(",", ":"), sort_keys=True)
+        return data.encode('utf-8')
+
+    def deserialize(self, stream):
+        import json
+        text = stream.decode('utf-8')
+        return json.loads(text)
+
+
+class TensorBuilder:
+    def __init__(self, reporter=None):
+        self._reporter = reporter
+
+    def to_tensor(self, tokens):
+        import torch
+        tensor = torch.tensor(tokens, dtype=torch.int64)
+        return tensor
+
+    def to_tokens(self, tensor):
+        return [int(x) for x in tensor.tolist()]
+
+
+class PoTEDPipeline:
+    def __init__(self, serializer, tokenizer, tensor_builder, reporter=None):
+        self._serializer = serializer
+        self._tokenizer = tokenizer
+        self._tensor_builder = tensor_builder
+        self._reporter = reporter
+
+    def encode(self, obj):
+        stream = self._serializer.serialize(obj)
+        tokens = self._tokenizer.tokenize(stream)
+        tensor = self._tensor_builder.to_tensor(tokens)
+        if self._reporter:
+            total = len(tokens)
+            self._reporter.report('total_tokens', 'Total number of tokens', total)
+            ratio = len(tokens) / len(stream) if stream else 0
+            self._reporter.report('compression_ratio', 'Token count to byte length ratio', ratio)
+        return tensor
+
+    def decode(self, tensor):
+        tokens = self._tensor_builder.to_tokens(tensor)
+        stream = self._tokenizer.detokenize(tokens)
+        return self._serializer.deserialize(stream)

--- a/poted/tokenizer.py
+++ b/poted/tokenizer.py
@@ -82,3 +82,12 @@ class StreamingTokenizer:
             self._add_sequence(prev + (seq[0],))
             prev = seq
         return result
+
+    def tokenize(self, stream):
+        encoded = self.encode(stream)
+        return [int(t) for t in encoded]
+
+    def detokenize(self, tokens):
+        from .core import Token
+        decoded = self.decode([Token(t) for t in tokens])
+        return bytes(decoded)

--- a/tests/test_pipeline_roundtrip.py
+++ b/tests/test_pipeline_roundtrip.py
@@ -1,0 +1,38 @@
+import unittest
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+import main
+from poted.tokenizer import StreamingTokenizer
+from poted.pipeline import JsonSerializer, TensorBuilder, PoTEDPipeline
+
+
+class TestPoTEDPipelineRoundtrip(unittest.TestCase):
+    def setUp(self):
+        main.Reporter._metrics = {}
+        self.serializer = JsonSerializer()
+        self.tokenizer = StreamingTokenizer(main.Reporter)
+        self.builder = TensorBuilder()
+        self.pipeline = PoTEDPipeline(
+            self.serializer, self.tokenizer, self.builder, main.Reporter
+        )
+
+    def test_roundtrip(self):
+        obj = {"numbers": [1, 2, 3], "nested": {"flag": True}}
+        tensor = self.pipeline.encode(obj)
+        result = self.pipeline.decode(tensor)
+        self.assertEqual(result, obj)
+        stream = self.serializer.serialize(obj)
+        tokens = StreamingTokenizer().tokenize(stream)
+        expected_ratio = len(tokens) / len(stream)
+        self.assertEqual(main.Reporter.report('total_tokens'), len(tokens))
+        self.assertAlmostEqual(
+            main.Reporter.report('compression_ratio'), expected_ratio
+        )
+        print('Total tokens:', main.Reporter.report('total_tokens'))
+        print('Compression ratio:', main.Reporter.report('compression_ratio'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Extend `StreamingTokenizer` with `tokenize` and `detokenize` helpers for integer token streams
- Add `JsonSerializer`, `TensorBuilder`, and `PoTEDPipeline` to serialize objects into tensors and back
- Provide integration test covering end-to-end pipeline and metrics reporting

## Testing
- `pytest tests/test_streaming_tokenizer.py tests/test_pipeline_roundtrip.py -q -s`

------
https://chatgpt.com/codex/tasks/task_e_68bfee1376088327a3061a6a31e2737e