### PR TITLE
Implement control tokens and validation

### DIFF
--- a/poted/control.py
+++ b/poted/control.py
@@ -1,0 +1,5 @@
+class ControlToken(__import__('enum').IntEnum):
+    BOS = -1
+    EOS = -2
+    RST = -3
+    SYNC = -4

--- a/poted/validator.py
+++ b/poted/validator.py
@@ -1,0 +1,17 @@
+class ProtocolValidator:
+    @classmethod
+    def validate(cls, tokens):
+        from .control import ControlToken
+        from main import Reporter
+        if not tokens:
+            raise ValueError('Token stream empty')
+        if tokens[0] != int(ControlToken.BOS):
+            raise ValueError('Missing BOS')
+        if tokens[-1] != int(ControlToken.EOS):
+            raise ValueError('Missing EOS')
+        if len(tokens) < 3 or tokens[1] != int(ControlToken.RST):
+            raise ValueError('Missing RST after BOS')
+        if tokens[2] != int(ControlToken.SYNC):
+            raise ValueError('Missing SYNC after RST')
+        Reporter.report('validated_tokens', 'Number of tokens validated', len(tokens))
+        return True

--- a/tests/test_control_tokens.py
+++ b/tests/test_control_tokens.py
@@ -1,0 +1,44 @@
+import sys
+import pathlib
+import unittest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+import main
+from poted.tokenizer import StreamingTokenizer
+from poted.control import ControlToken
+from poted.validator import ProtocolValidator
+
+
+class TestControlTokens(unittest.TestCase):
+    def test_tokenize_inserts_control_tokens(self):
+        stream = b'friend'
+        tokenizer = StreamingTokenizer(main.Reporter)
+        tokens = tokenizer.tokenize(stream)
+        print('Tokenized with control tokens:', tokens)
+        self.assertEqual(tokens[0], int(ControlToken.BOS))
+        self.assertEqual(tokens[1], int(ControlToken.RST))
+        self.assertEqual(tokens[2], int(ControlToken.SYNC))
+        self.assertEqual(tokens[-1], int(ControlToken.EOS))
+        payload = tokens[3:-1]
+        self.assertTrue(all(t >= 0 for t in payload))
+
+    def test_detokenize_roundtrip(self):
+        stream = b'buddyo'
+        tokenizer = StreamingTokenizer(main.Reporter)
+        tokens = tokenizer.tokenize(stream)
+        decoded = tokenizer.detokenize(tokens)
+        print('Decoded stream:', decoded)
+        self.assertEqual(decoded, stream)
+
+    def test_validator(self):
+        stream = b'pal'
+        tokenizer = StreamingTokenizer(main.Reporter)
+        tokens = tokenizer.tokenize(stream)
+        print('Validating tokens:', tokens)
+        self.assertTrue(ProtocolValidator.validate(tokens))
+        with self.assertRaises(ValueError):
+            ProtocolValidator.validate(tokens[1:])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- define ControlToken enum
- add protocol-aware tokenization with BOS, EOS, RST and SYNC
- validate control token sequence
- test control token roundtrip

## Testing
- `pytest tests/test_control_tokens.py -q`
- `pytest tests/test_poted_core.py tests/test_streaming_tokenizer.py tests/test_pipeline_roundtrip.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfef6f39bc83279819198b095e3467