### PR TITLE
feat: add streaming decoder with state resets

### DIFF
--- a/poted/decoder.py
+++ b/poted/decoder.py
@@ -1,0 +1,56 @@
+class StreamingDecoder:
+    def __init__(self, reporter=None):
+        self._reporter = reporter
+        self._reset_state()
+
+    def _reset_state(self):
+        from .core import Token
+        self._rev_dict = {}
+        self._next = 0
+        for i in range(256):
+            token = Token(self._next)
+            self._rev_dict[int(token)] = (i,)
+            self._next += 1
+
+    def _add_sequence(self, seq):
+        from .core import Token
+        token = Token(self._next)
+        self._rev_dict[int(token)] = seq
+        self._next += 1
+
+    def decode(self, tokens):
+        from .core import Token
+        from .control import ControlToken
+        from .validator import ProtocolValidator
+        ProtocolValidator.validate(tokens)
+        result = []
+        prev = None
+        for t in tokens:
+            if t == int(ControlToken.RST):
+                self._reset_state()
+                if self._reporter:
+                    count = self._reporter.report('decoder_mutations') or 0
+                    self._reporter.report(
+                        'decoder_mutations',
+                        'Number of decoder state resets',
+                        count + 1,
+                    )
+                prev = None
+                continue
+            if t in (
+                int(ControlToken.BOS),
+                int(ControlToken.EOS),
+                int(ControlToken.SYNC),
+            ):
+                continue
+            token = Token(t)
+            seq = self._rev_dict.get(int(token))
+            if seq is None:
+                if prev is None:
+                    raise KeyError('Unknown token')
+                seq = prev + (prev[0],)
+            result.extend(seq)
+            if prev is not None:
+                self._add_sequence(prev + (seq[0],))
+            prev = seq
+        return bytes(result)

--- a/tests/test_decoder_learning.py
+++ b/tests/test_decoder_learning.py
@@ -1,0 +1,32 @@
+import unittest
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+import main
+from poted.tokenizer import StreamingTokenizer
+from poted.decoder import StreamingDecoder
+
+
+class TestStreamingDecoderLearning(unittest.TestCase):
+    def setUp(self):
+        main.Reporter._metrics = {}
+
+    def test_roundtrip_with_mutations(self):
+        tokenizer = StreamingTokenizer()
+        decoder = StreamingDecoder(main.Reporter)
+        stream1 = b'abab'
+        stream2 = b'cdcd'
+        tokens1 = tokenizer.tokenize(stream1)
+        tokens2 = tokenizer.tokenize(stream2)
+        tokens = tokens1[:-1] + tokens2[1:]
+        decoded = decoder.decode(tokens)
+        self.assertEqual(decoded, stream1 + stream2)
+        self.assertEqual(main.Reporter.report('decoder_mutations'), 2)
+        print('Combined tokens:', tokens)
+        print('Decoded stream:', decoded)
+        print('Decoder mutations metric:', main.Reporter.report('decoder_mutations'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement StreamingDecoder that learns words via LZ78 rule and handles RST mutations
- track decoder state resets through `decoder_mutations` metric
- add roundtrip test ensuring decoder correctly rebuilds streams and reports mutations

## Testing
- `python -m pytest tests/test_decoder_learning.py tests/test_streaming_tokenizer.py -q -s`


------
https://chatgpt.com/codex/tasks/task_e_68bff4573d208327912fb1fd38bd3a8b