### PR TITLE
Implement persistent dictionary manager with test coverage

### DIFF
--- a/poted/dictionary.py
+++ b/poted/dictionary.py
@@ -1,0 +1,106 @@
+class DictionaryManager:
+    def __init__(self, reporter=None, max_word_length=16, mode='volatile'):
+        from .core import ByteAlphabet
+        self._reporter = reporter
+        self._max_word_length = max_word_length
+        self._mode = mode
+        self._alphabet = ByteAlphabet()
+        self._dict = {}
+        self._rev_dict = {}
+        self._next = 0
+        self._longest = 1
+        self.reset()
+        if self._mode == 'persistent' and self._reporter:
+            count = self._reporter.report('persistent_sessions') or 0
+            self._reporter.report(
+                'persistent_sessions',
+                'Number of persistent dictionary sessions',
+                count + 1,
+            )
+
+    def reset(self):
+        if self._mode == 'persistent' and self._dict:
+            return
+        from .core import Token
+        self._dict = {}
+        self._rev_dict = {}
+        self._next = 0
+        self._longest = 1
+        for i in range(256):
+            token = Token(self._next)
+            self._dict[(i,)] = token
+            self._rev_dict[int(token)] = (i,)
+            self._next += 1
+        if self._reporter:
+            self._reporter.report(
+                'dictionary_size',
+                'Number of entries in tokenizer dictionary',
+                self._next,
+            )
+            self._reporter.report(
+                'longest_match',
+                'Length of longest match during tokenization',
+                self._longest,
+            )
+
+    def add_sequence(self, seq):
+        if len(seq) > self._max_word_length or seq in self._dict:
+            return
+        from .core import Token
+        token = Token(self._next)
+        self._dict[seq] = token
+        self._rev_dict[int(token)] = seq
+        self._next += 1
+        if self._reporter:
+            self._reporter.report('dictionary_size', value=self._next)
+
+    def update_longest(self, length):
+        if length > self._longest:
+            self._longest = length
+            if self._reporter:
+                self._reporter.report('longest_match', value=length)
+
+    def encode(self, data):
+        if isinstance(data, bytes):
+            data = list(data)
+        if not data:
+            return []
+        for b in data:
+            if not self._alphabet.contains(b):
+                raise ValueError('Byte out of alphabet')
+        result = []
+        w = (data[0],)
+        for b in data[1:]:
+            c = (b,)
+            if len(w) < self._max_word_length and w + c in self._dict:
+                w = w + c
+            else:
+                result.append(self._dict[w])
+                self.update_longest(len(w))
+                if len(w) < self._max_word_length:
+                    self.add_sequence(w + c)
+                w = c
+        result.append(self._dict[w])
+        self.update_longest(len(w))
+        return result
+
+    def decode(self, tokens):
+        if not tokens:
+            return []
+        result = []
+        prev = self._rev_dict.get(int(tokens[0]))
+        if prev is None:
+            raise KeyError('Unknown token')
+        result.extend(prev)
+        for t in tokens[1:]:
+            seq = self._rev_dict.get(int(t))
+            if seq is None:
+                seq = prev + (prev[0],)
+            result.extend(seq)
+            self.add_sequence(prev + (seq[0],))
+            prev = seq
+        return result
+
+    @property
+    def reporter(self):
+        return self._reporter

--- a/poted/tokenizer.py
+++ b/poted/tokenizer.py
@@ -1,94 +1,17 @@
 class StreamingTokenizer:
-    def __init__(self, reporter=None, max_word_length=16):
-        self._reporter = reporter
-        self._max_word_length = max_word_length
-        self._reset_state()
-
-    def _reset_state(self):
-        from .core import ByteAlphabet, Token
-        self._alphabet = ByteAlphabet()
-        self._dict = {}
-        self._rev_dict = {}
-        self._next = 0
-        self._longest = 1
-        for i in range(256):
-            token = Token(self._next)
-            self._dict[(i,)] = token
-            self._rev_dict[int(token)] = (i,)
-            self._next += 1
-        if self._reporter:
-            self._reporter.report(
-                'dictionary_size',
-                'Number of entries in tokenizer dictionary',
-                self._next,
-            )
-            self._reporter.report(
-                'longest_match',
-                'Length of longest match during tokenization',
-                self._longest,
-            )
-
-    def _add_sequence(self, seq):
-        if len(seq) > self._max_word_length or seq in self._dict:
-            return
-        from .core import Token
-        token = Token(self._next)
-        self._dict[seq] = token
-        self._rev_dict[int(token)] = seq
-        self._next += 1
-        if self._reporter:
-            self._reporter.report('dictionary_size', value=self._next)
-
-    def _update_longest(self, length):
-        if length > self._longest:
-            self._longest = length
-            if self._reporter:
-                self._reporter.report('longest_match', value=length)
+    def __init__(self, reporter=None, max_word_length=16, mode='volatile'):
+        from .dictionary import DictionaryManager
+        self._manager = DictionaryManager(reporter, max_word_length, mode)
 
     def encode(self, data):
-        if isinstance(data, bytes):
-            data = list(data)
-        if not data:
-            return []
-        for b in data:
-            if not self._alphabet.contains(b):
-                raise ValueError('Byte out of alphabet')
-        result = []
-        w = (data[0],)
-        for b in data[1:]:
-            c = (b,)
-            if len(w) < self._max_word_length and w + c in self._dict:
-                w = w + c
-            else:
-                result.append(self._dict[w])
-                self._update_longest(len(w))
-                if len(w) < self._max_word_length:
-                    self._add_sequence(w + c)
-                w = c
-        result.append(self._dict[w])
-        self._update_longest(len(w))
-        return result
+        return self._manager.encode(data)
 
     def decode(self, tokens):
-        if not tokens:
-            return []
-        result = []
-        prev = self._rev_dict.get(int(tokens[0]))
-        if prev is None:
-            raise KeyError('Unknown token')
-        result.extend(prev)
-        for t in tokens[1:]:
-            seq = self._rev_dict.get(int(t))
-            if seq is None:
-                seq = prev + (prev[0],)
-            result.extend(seq)
-            self._add_sequence(prev + (seq[0],))
-            prev = seq
-        return result
+        return self._manager.decode(tokens)
 
     def tokenize(self, stream):
         from .control import ControlToken
-        self._reset_state()
+        self._manager.reset()
         encoded = self.encode(stream)
         tokens = [
             int(ControlToken.BOS),
@@ -97,8 +20,8 @@ class StreamingTokenizer:
         ]
         tokens.extend(int(t) for t in encoded)
         tokens.append(int(ControlToken.EOS))
-        if self._reporter:
-            self._reporter.report(
+        if self._manager.reporter:
+            self._manager.reporter.report(
                 'control_tokens_added',
                 'Number of control tokens added to stream',
                 4,
@@ -113,7 +36,7 @@ class StreamingTokenizer:
         payload = []
         for t in tokens:
             if t == int(ControlToken.RST):
-                self._reset_state()
+                self._manager.reset()
                 continue
             if t in (
                 int(ControlToken.BOS),

--- a/tests/test_dictionary_persistence.py
+++ b/tests/test_dictionary_persistence.py
@@ -1,0 +1,43 @@
+import unittest
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+import main
+from poted.tokenizer import StreamingTokenizer
+
+
+class TestDictionaryPersistence(unittest.TestCase):
+    def setUp(self):
+        main.Reporter._metrics = {}
+
+    def test_volatile_reset(self):
+        tokenizer = StreamingTokenizer(main.Reporter, max_word_length=8, mode='volatile')
+        stream = [65, 66, 65, 66]
+        tokenizer.tokenize(stream)
+        size_first = main.Reporter.report('dictionary_size')
+        tokens = tokenizer.tokenize(stream)
+        tokenizer.detokenize(tokens)
+        size_second = main.Reporter.report('dictionary_size')
+        print('Volatile size after first:', size_first)
+        print('Volatile size after second:', size_second)
+        self.assertEqual(size_second, size_first)
+
+    def test_persistent_keeps_dictionary(self):
+        tokenizer = StreamingTokenizer(main.Reporter, max_word_length=8, mode='persistent')
+        stream = [65, 66, 65, 66]
+        tokenizer.tokenize(stream)
+        size_before = main.Reporter.report('dictionary_size')
+        tokens = tokenizer.tokenize(stream)
+        tokenizer.detokenize(tokens)
+        size_after = main.Reporter.report('dictionary_size')
+        sessions = main.Reporter.report('persistent_sessions')
+        print('Persistent size before:', size_before)
+        print('Persistent size after:', size_after)
+        print('Persistent sessions metric:', sessions)
+        self.assertTrue(size_after > size_before)
+        self.assertEqual(sessions, 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `DictionaryManager` supporting `persistent` and `volatile` modes
- track persistent sessions via `persistent_sessions` reporter metric
- integrate manager into `StreamingTokenizer`
- test dictionary persistence behavior

## Testing
- `python -m pytest tests/test_streaming_tokenizer.py tests/test_pipeline_roundtrip.py tests/test_dictionary_persistence.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bff560221c8327954416ae032fa8c6