### PR TITLE
Add roundtrip utility and property-based tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 torch
+hypothesis

--- a/tests/test_roundtrip_properties.py
+++ b/tests/test_roundtrip_properties.py
@@ -1,0 +1,34 @@
+import unittest
+import sys
+import pathlib
+
+tests_dir = pathlib.Path(__file__).resolve().parent
+sys.path.append(str(tests_dir))
+sys.path.append(str(tests_dir.parent))
+
+import main
+from hypothesis import given, strategies as st
+from utils import roundtrip
+
+json_strategy = st.recursive(
+    st.none() | st.booleans() | st.integers() | st.floats(allow_nan=False, allow_infinity=False) | st.text(),
+    lambda children: st.lists(children, max_size=5) | st.dictionaries(st.text(), children, max_size=5),
+    max_leaves=20,
+)
+
+
+class TestRoundtripProperties(unittest.TestCase):
+    @given(json_strategy)
+    def test_roundtrip_identity(self, obj):
+        main.Reporter._metrics = {}
+        result = roundtrip(obj)
+        print('Roundtrip object:', obj)
+        self.assertEqual(result, obj)
+        self.assertIsNone(main.Reporter.report('roundtrip_failures'))
+
+    def test_roundtrip_failure_metrics(self):
+        main.Reporter._metrics = {}
+        with self.assertRaises(TypeError):
+            roundtrip({1, 2, 3})
+        self.assertEqual(main.Reporter.report('roundtrip_failures'), 1)
+        print('Roundtrip failures:', main.Reporter.report('roundtrip_failures'))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,30 @@
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+
+import main
+from poted.tokenizer import StreamingTokenizer
+from poted.pipeline import JsonSerializer, TensorBuilder, PoTEDPipeline
+
+
+def roundtrip(obj):
+    serializer = JsonSerializer()
+    tokenizer = StreamingTokenizer(main.Reporter)
+    builder = TensorBuilder()
+    pipeline = PoTEDPipeline(serializer, tokenizer, builder, main.Reporter)
+    try:
+        tensor = pipeline.encode(obj)
+        result = pipeline.decode(tensor)
+        if result != obj:
+            count = main.Reporter.report('roundtrip_failures') or 0
+            main.Reporter.report(
+                'roundtrip_failures', 'Number of failed roundtrip comparisons', count + 1
+            )
+        return result
+    except Exception:
+        count = main.Reporter.report('roundtrip_failures') or 0
+        main.Reporter.report(
+            'roundtrip_failures', 'Number of failed roundtrip comparisons', count + 1
+        )
+        raise


### PR DESCRIPTION
## Summary
- add roundtrip helper using PoTED pipeline and reporter metric for failures
- add Hypothesis-driven roundtrip property tests and failure metric test
- add Hypothesis to requirements

## Testing
- `HYPOTHESIS_MAX_EXAMPLES=2 pytest tests/test_roundtrip_properties.py::TestRoundtripProperties::test_roundtrip_identity -q -s | tail -n 5`
- `pytest tests/test_roundtrip_properties.py::TestRoundtripProperties::test_roundtrip_failure_metrics -q -s`
- `pytest tests/test_pipeline_roundtrip.py::TestPoTEDPipelineRoundtrip::test_roundtrip -q -s`


------
https://chatgpt.com/codex/tasks/task_e_68c002d7202c83278b5b64b2b985ff32