### PR TITLE
Estimate tokenizer/decoder complexity

### DIFF
--- a/poted/decoder.py
+++ b/poted/decoder.py
@@ -53,4 +53,18 @@ class StreamingDecoder:
             if prev is not None:
                 self._add_sequence(prev + (seq[0],))
             prev = seq
-        return bytes(result)
+        output = bytes(result)
+        if self._reporter:
+            steps = len(tokens)
+            previous = self._reporter.report('decoder_steps') or 0
+            self._reporter.report(
+                'decoder_steps',
+                'Estimated steps taken by decoder',
+                previous + steps,
+            )
+            import sys
+            memory = sys.getsizeof(tokens) + sys.getsizeof(output) + sys.getsizeof(self._rev_dict)
+            current = self._reporter.report('max_memory_bytes') or 0
+            if memory > current:
+                self._reporter.report('max_memory_bytes', 'Maximum memory usage in bytes', memory)
+        return output

--- a/poted/tokenizer.py
+++ b/poted/tokenizer.py
@@ -4,10 +4,40 @@ class StreamingTokenizer:
         self._manager = DictionaryManager(reporter, max_word_length, mode)
 
     def encode(self, data):
-        return self._manager.encode(data)
+        encoded = self._manager.encode(data)
+        reporter = self._manager.reporter
+        if reporter:
+            steps = len(data)
+            previous = reporter.report('tokenizer_steps') or 0
+            reporter.report(
+                'tokenizer_steps',
+                'Estimated steps taken by tokenizer',
+                previous + steps,
+            )
+            import sys
+            memory = sys.getsizeof(encoded) + sys.getsizeof(self._manager._dict) + sys.getsizeof(self._manager._rev_dict)
+            current = reporter.report('max_memory_bytes') or 0
+            if memory > current:
+                reporter.report('max_memory_bytes', 'Maximum memory usage in bytes', memory)
+        return encoded
 
     def decode(self, tokens):
-        return self._manager.decode(tokens)
+        decoded = self._manager.decode(tokens)
+        reporter = self._manager.reporter
+        if reporter:
+            steps = len(tokens)
+            previous = reporter.report('tokenizer_steps') or 0
+            reporter.report(
+                'tokenizer_steps',
+                'Estimated steps taken by tokenizer',
+                previous + steps,
+            )
+            import sys
+            memory = sys.getsizeof(tokens) + sys.getsizeof(decoded) + sys.getsizeof(self._manager._dict) + sys.getsizeof(self._manager._rev_dict)
+            current = reporter.report('max_memory_bytes') or 0
+            if memory > current:
+                reporter.report('max_memory_bytes', 'Maximum memory usage in bytes', memory)
+        return decoded
 
     def tokenize(self, stream):
         from .control import ControlToken

--- a/tests/test_complexity_reporting.py
+++ b/tests/test_complexity_reporting.py
@@ -1,0 +1,34 @@
+import unittest
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+import main
+from poted.tokenizer import StreamingTokenizer
+from poted.decoder import StreamingDecoder
+
+
+class TestComplexityReporting(unittest.TestCase):
+    def setUp(self):
+        main.Reporter._metrics = {}
+
+    def test_complexity_metrics(self):
+        tokenizer = StreamingTokenizer(main.Reporter)
+        decoder = StreamingDecoder(main.Reporter)
+        data = b"hello world"
+        tokens = tokenizer.tokenize(data)
+        decoded = decoder.decode(tokens)
+        self.assertEqual(decoded, data)
+        tok_steps = main.Reporter.report('tokenizer_steps')
+        dec_steps = main.Reporter.report('decoder_steps')
+        max_mem = main.Reporter.report('max_memory_bytes')
+        print('Tokenizer steps:', tok_steps)
+        print('Decoder steps:', dec_steps)
+        print('Max memory bytes:', max_mem)
+        self.assertGreaterEqual(tok_steps, len(data))
+        self.assertGreaterEqual(dec_steps, len(tokens))
+        self.assertGreater(max_mem, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- track rough step counts in streaming tokenizer and decoder
- record peak memory usage via reporter
- verify complexity metrics with new unit test

## Testing
- `python -m pytest tests/test_complexity_reporting.py -q`
- `python -m pytest tests/test_streaming_tokenizer.py::TestStreamingTokenizer::test_roundtrip tests/test_decoder_learning.py::TestStreamingDecoderLearning::test_roundtrip_with_mutations -q`
- `python -m pytest tests/test_complexity_reporting.py tests/test_streaming_tokenizer.py::TestStreamingTokenizer::test_roundtrip tests/test_decoder_learning.py::TestStreamingDecoderLearning::test_roundtrip_with_mutations -q`


------
https://chatgpt.com/codex/tasks/task_e_68c00421a63c8327b820e76ede5c712c