### PR TITLE
Add device-aware TensorBuilder and tests

### DIFF
--- a/poted/pipeline.py
+++ b/poted/pipeline.py
@@ -1,3 +1,6 @@
+from poted.tensor import TensorBuilder
+
+
 class JsonSerializer:
     def serialize(self, obj):
         import json
@@ -9,45 +12,6 @@ class JsonSerializer:
         text = stream.decode('utf-8')
         return json.loads(text)
 
-
-class TensorBuilder:
-    PAD = -5
-
-    def __init__(self, Lw=0, Le=0, Lu=0, reporter=None):
-        self._Lw = Lw
-        self._Le = Le
-        self._Lu = Lu
-        self._reporter = reporter
-
-    def to_tensor(self, tokens):
-        import torch
-        sequences = tokens if tokens and isinstance(tokens[0], list) else [tokens]
-        L = self._Lw + self._Le + self._Lu
-        if L <= 0:
-            L = max((len(seq) for seq in sequences), default=0)
-        padded = []
-        for seq in sequences:
-            if len(seq) < L:
-                seq = seq + [self.PAD] * (L - len(seq))
-            else:
-                seq = seq[:L]
-            padded.append(seq)
-        tensor = torch.tensor(padded, dtype=torch.int64)
-        if self._reporter:
-            self._reporter.report(
-                'tensor_shape',
-                'Shape of tensor produced by TensorBuilder',
-                list(tensor.shape),
-            )
-        return tensor
-
-    def to_tokens(self, tensor):
-        tokens = []
-        for row in tensor.tolist():
-            for x in row:
-                if x != self.PAD:
-                    tokens.append(int(x))
-        return tokens
 
 
 class PoTEDPipeline:

--- a/poted/tensor.py
+++ b/poted/tensor.py
@@ -1,0 +1,44 @@
+class TensorBuilder:
+    PAD = -5
+
+    def __init__(self, Lw=0, Le=0, Lu=0, device='cpu', reporter=None):
+        import torch
+        self._Lw = Lw
+        self._Le = Le
+        self._Lu = Lu
+        self._device = torch.device(device)
+        self._reporter = reporter
+
+    def from_tokens(self, tokens, device=None):
+        import torch
+        sequences = tokens if tokens and isinstance(tokens[0], list) else [tokens]
+        L = self._Lw + self._Le + self._Lu
+        if L <= 0:
+            L = max((len(seq) for seq in sequences), default=0)
+        padded = []
+        for seq in sequences:
+            if len(seq) < L:
+                seq = seq + [self.PAD] * (L - len(seq))
+            else:
+                seq = seq[:L]
+            padded.append(seq)
+        target_device = torch.device(device) if device is not None else self._device
+        tensor = torch.tensor(padded, dtype=torch.int64, device=target_device)
+        if self._reporter:
+            self._reporter.report(
+                'tensor_shape',
+                'Shape of tensor produced by TensorBuilder',
+                list(tensor.shape),
+            )
+        return tensor
+
+    def to_tensor(self, tokens, device=None):
+        return self.from_tokens(tokens, device=device)
+
+    def to_tokens(self, tensor):
+        tokens = []
+        for row in tensor.tolist():
+            for x in row:
+                if x != self.PAD:
+                    tokens.append(int(x))
+        return tokens

--- a/tests/test_tensor_builder.py
+++ b/tests/test_tensor_builder.py
@@ -1,0 +1,31 @@
+import unittest
+import sys
+import pathlib
+import torch
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+import main
+from poted.tensor import TensorBuilder
+
+
+class TestTensorBuilderDeviceSwitch(unittest.TestCase):
+    def setUp(self):
+        main.Reporter._metrics = {}
+
+    def test_device_switch(self):
+        tokens = [[1, 2, 3], [4, 5]]
+        builder = TensorBuilder(device='cpu', reporter=main.Reporter)
+        tensor_cpu = builder.from_tokens(tokens)
+        print('CPU tensor:', tensor_cpu, 'device:', tensor_cpu.device)
+        self.assertEqual(str(tensor_cpu.device), 'cpu')
+        if torch.cuda.is_available():
+            tensor_gpu = builder.from_tokens(tokens, device='cuda:0')
+            print('GPU tensor:', tensor_gpu, 'device:', tensor_gpu.device)
+            self.assertTrue(str(tensor_gpu.device).startswith('cuda'))
+            tensor_back = builder.from_tokens(tokens)
+            print('Tensor back on default device:', tensor_back.device)
+            self.assertEqual(str(tensor_back.device), 'cpu')
+        else:
+            print('CUDA not available; GPU test skipped')
+        print('Reported shape:', main.Reporter.report('tensor_shape'))
+        self.assertEqual(main.Reporter.report('tensor_shape'), list(tensor_cpu.shape))


### PR DESCRIPTION
## Summary
- introduce dedicated `TensorBuilder` module supporting CPU/GPU selection
- refactor pipeline to reuse the shared `TensorBuilder`
- add tests verifying tensor creation and device switching

## Testing
- `python -m pytest tests/test_tensor_builder.py tests/test_tensor_shapes.py tests/test_pipeline_roundtrip.py -q -s`

------
https://chatgpt.com/codex/tasks/task_e_68c0054d808883279620108b586e94e1