### PR TITLE
Add portable mode to PoTED pipeline with dictionary embedding

### DIFF
--- a/poted/dictionary.py
+++ b/poted/dictionary.py
@@ -101,6 +101,12 @@ class DictionaryManager:
             prev = seq
         return result
 
+    def export(self):
+        entries = []
+        for seq, token in sorted(self._dict.items(), key=lambda item: int(item[1])):
+            entries.append({"seq": list(seq), "token": int(token)})
+        return entries
+
     @property
     def reporter(self):
         return self._reporter

--- a/tests/test_instance_mode.py
+++ b/tests/test_instance_mode.py
@@ -1,0 +1,35 @@
+import unittest
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+import main
+from poted.pipeline import JsonSerializer, TensorBuilder, PoTEDPipeline
+from poted.tokenizer import StreamingTokenizer
+
+
+class TestInstanceMode(unittest.TestCase):
+    def setUp(self):
+        main.Reporter._metrics = {}
+        self.serializer = JsonSerializer()
+        self.tokenizer = StreamingTokenizer()
+        self.builder = TensorBuilder()
+        self.pipeline = PoTEDPipeline(
+            self.serializer, self.tokenizer, self.builder, mode='instance'
+        )
+
+    def test_no_dictionary_included(self):
+        obj = {"values": [4, 5, 6]}
+        tensor = self.pipeline.encode(obj)
+        tokens = self.builder.to_tokens(tensor)
+        stream = self.tokenizer.detokenize(tokens)
+        decoded = self.serializer.deserialize(stream)
+        self.assertEqual(decoded, obj)
+        self.assertNotIn('dictionary', decoded)
+        result = self.pipeline.decode(tensor)
+        self.assertEqual(result, obj)
+        print('Token count:', len(tokens))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_portable_mode.py
+++ b/tests/test_portable_mode.py
@@ -1,0 +1,36 @@
+import unittest
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+import main
+from poted.pipeline import JsonSerializer, TensorBuilder, PoTEDPipeline
+from poted.tokenizer import StreamingTokenizer
+
+
+class TestPortableMode(unittest.TestCase):
+    def setUp(self):
+        main.Reporter._metrics = {}
+        self.serializer = JsonSerializer()
+        self.tokenizer = StreamingTokenizer()
+        self.builder = TensorBuilder()
+        self.pipeline = PoTEDPipeline(
+            self.serializer, self.tokenizer, self.builder, mode='portable'
+        )
+
+    def test_dictionary_included(self):
+        obj = {"numbers": [1, 2, 3]}
+        tensor = self.pipeline.encode(obj)
+        tokens = self.builder.to_tokens(tensor)
+        stream = self.tokenizer.detokenize(tokens)
+        wrapped = self.serializer.deserialize(stream)
+        self.assertIn('dictionary', wrapped)
+        self.assertIn('payload', wrapped)
+        self.assertEqual(wrapped['payload'], obj)
+        result = self.pipeline.decode(tensor)
+        self.assertEqual(result, obj)
+        print('Dictionary entries:', len(wrapped['dictionary']))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Allow PoTEDPipeline to operate in `portable` or `instance` mode
- Embed tokenizer dictionary in the stream when running in portable mode
- Add tests covering portable and instance pipeline behaviour

## Testing
- `pytest tests/test_portable_mode.py tests/test_instance_mode.py -q`
- `pytest tests/test_pipeline_roundtrip.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c00e007f8c8327acc1304704e874a5