### PR TITLE
Add decoder sync error handling

### DIFF
--- a/poted/decoder.py
+++ b/poted/decoder.py
@@ -47,7 +47,16 @@ class StreamingDecoder:
             seq = self._rev_dict.get(int(token))
             if seq is None:
                 if prev is None:
-                    raise KeyError('Unknown token')
+                    self._reset_state()
+                    if self._reporter:
+                        count = self._reporter.report('sync_resets') or 0
+                        self._reporter.report(
+                            'sync_resets',
+                            'Number of decoder synchronisation resets',
+                            count + 1,
+                        )
+                    from .errors import DictionaryMismatch
+                    raise DictionaryMismatch('Unknown token')
                 seq = prev + (prev[0],)
             result.extend(seq)
             if prev is not None:

--- a/poted/errors.py
+++ b/poted/errors.py
@@ -1,0 +1,10 @@
+class SyncError(Exception):
+    """Raised when a synchronization issue occurs in the token stream."""
+    def __init__(self, message="Token stream out of sync"):
+        super().__init__(message)
+
+
+class DictionaryMismatch(SyncError):
+    """Raised when decoder and encoder dictionaries become inconsistent."""
+    def __init__(self, message="Dictionary mismatch detected"):
+        super().__init__(message)

--- a/tests/test_error_cases.py
+++ b/tests/test_error_cases.py
@@ -1,0 +1,36 @@
+import unittest
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+import main
+from poted.decoder import StreamingDecoder
+from poted.errors import SyncError, DictionaryMismatch
+from poted.control import ControlToken
+
+
+class TestErrorCases(unittest.TestCase):
+    def setUp(self):
+        main.Reporter._metrics = {}
+
+    def test_dictionary_mismatch_triggers_reset(self):
+        decoder = StreamingDecoder(reporter=main.Reporter)
+        tokens = [
+            int(ControlToken.BOS),
+            int(ControlToken.RST),
+            int(ControlToken.SYNC),
+            999,
+            int(ControlToken.EOS),
+        ]
+        with self.assertRaises(DictionaryMismatch):
+            decoder.decode(tokens)
+        resets = main.Reporter.report('sync_resets')
+        print('Sync resets:', resets)
+        self.assertEqual(resets, 1)
+
+    def test_exception_hierarchy(self):
+        self.assertTrue(issubclass(DictionaryMismatch, SyncError))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- define SyncError and DictionaryMismatch exceptions for synchronization issues
- reset decoder and report `sync_resets` when encountering mismatched tokens
- cover decoder sync errors and exception hierarchy with new tests

## Testing
- `python -m pytest tests/test_error_cases.py tests/test_decoder_learning.py tests/test_pipeline_roundtrip.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c00f805b8c8327957cf597c7c181d4