### PR TITLE
Fix TensorBuilder.to_tokens regression and add coverage

### DIFF
--- a/poted/tensor.py
+++ b/poted/tensor.py
@@ -36,9 +36,17 @@ class TensorBuilder:
         return self.from_tokens(tokens, device=device)
 
     def to_tokens(self, tensor):
+        data = tensor.tolist() if hasattr(tensor, 'tolist') else tensor
+        sequences = data if data and isinstance(data[0], list) else [data]
         tokens = []
-        for row in tensor.tolist():
-            for x in row:
+        for seq in sequences:
+            for x in seq:
                 if x != self.PAD:
                     tokens.append(int(x))
+        if self._reporter:
+            self._reporter.report(
+                'extracted_tokens',
+                'Number of tokens extracted from tensor',
+                len(tokens),
+            )
         return tokens

--- a/tests/test_tensor_tokens.py
+++ b/tests/test_tensor_tokens.py
@@ -1,0 +1,33 @@
+import unittest
+import sys
+import pathlib
+import torch
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+import main
+from poted.tensor import TensorBuilder
+
+
+class TestTensorBuilderToTokens(unittest.TestCase):
+    def setUp(self):
+        main.Reporter._metrics = {}
+
+    def test_1d_tensor(self):
+        builder = TensorBuilder(reporter=main.Reporter)
+        tensor = torch.tensor([1, 2, 3], dtype=torch.int64)
+        tokens = builder.to_tokens(tensor)
+        print('Tokens from 1D tensor:', tokens)
+        print('Extracted tokens metric:', main.Reporter.report('extracted_tokens'))
+        self.assertEqual(tokens, [1, 2, 3])
+
+    def test_2d_tensor(self):
+        builder = TensorBuilder(reporter=main.Reporter)
+        tensor = torch.tensor([[1, 2, 3], [4, 5, builder.PAD]], dtype=torch.int64)
+        tokens = builder.to_tokens(tensor)
+        print('Tokens from 2D tensor:', tokens)
+        print('Extracted tokens metric:', main.Reporter.report('extracted_tokens'))
+        self.assertEqual(tokens, [1, 2, 3, 4, 5])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Normalize tensors in TensorBuilder.to_tokens so 1D inputs no longer crash and record extracted token count
- Add tests verifying token extraction for 1D and 2D tensors

## Testing
- `pytest tests/test_tensor_tokens.py tests/test_pipeline_roundtrip.py tests/test_tensor_builder.py -s`


------
https://chatgpt.com/codex/tasks/task_e_68c010a1e0c48327b4a58cccad1e84f1