### PR TITLE
Handle reset tokens during detokenization

### DIFF
--- a/poted/tokenizer.py
+++ b/poted/tokenizer.py
@@ -64,8 +64,12 @@ class StreamingTokenizer:
         from .validator import ProtocolValidator
         ProtocolValidator.validate(tokens)
         payload = []
+        decoded = bytearray()
         for t in tokens:
             if t == int(ControlToken.RST):
+                if payload:
+                    decoded.extend(self.decode(payload))
+                    payload.clear()
                 self._manager.reset()
                 continue
             if t in (
@@ -75,5 +79,6 @@ class StreamingTokenizer:
             ):
                 continue
             payload.append(Token(t))
-        decoded = self.decode(payload)
+        if payload:
+            decoded.extend(self.decode(payload))
         return bytes(decoded)

--- a/tests/test_control_tokens.py
+++ b/tests/test_control_tokens.py
@@ -39,6 +39,18 @@ class TestControlTokens(unittest.TestCase):
         with self.assertRaises(ValueError):
             ProtocolValidator.validate(tokens[1:])
 
+    def test_detokenize_handles_multiple_reset_segments(self):
+        stream1 = b'aaaaab'
+        stream2 = b'cccccc'
+        tokenizer = StreamingTokenizer(main.Reporter)
+        tokens1 = tokenizer.tokenize(stream1)
+        tokens2 = tokenizer.tokenize(stream2)
+        merged = tokens1[:-1] + tokens2[1:]
+        decoded = tokenizer.detokenize(merged)
+        print('Merged tokens:', merged)
+        print('Decoded merged stream:', decoded)
+        self.assertEqual(decoded, stream1 + stream2)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- Flush and decode segments whenever `ControlToken.RST` is encountered to keep tokenizer dictionary in sync
- Add regression test verifying detokenization across multiple reset segments

## Testing
- `python tests/test_control_tokens.py`
- `python tests/test_streaming_tokenizer.py`


------
https://chatgpt.com/codex/tasks/task_e_68c011d6982883278b381c9be60650a3