### PR TITLE
Guard unexpected tokens during decoding

### DIFF
--- a/poted/decoder.py
+++ b/poted/decoder.py
@@ -46,7 +46,7 @@ class StreamingDecoder:
             token = Token(t)
             seq = self._rev_dict.get(int(token))
             if seq is None:
-                if prev is None:
+                if prev is None or int(token) != self._next:
                     self._reset_state()
                     if self._reporter:
                         count = self._reporter.report('sync_resets') or 0

--- a/poted/dictionary.py
+++ b/poted/dictionary.py
@@ -95,6 +95,8 @@ class DictionaryManager:
         for t in tokens[1:]:
             seq = self._rev_dict.get(int(t))
             if seq is None:
+                if int(t) != self._next:
+                    raise KeyError('Unknown token')
                 seq = prev + (prev[0],)
             result.extend(seq)
             self.add_sequence(prev + (seq[0],))

--- a/tests/test_error_cases.py
+++ b/tests/test_error_cases.py
@@ -28,6 +28,22 @@ class TestErrorCases(unittest.TestCase):
         print('Sync resets:', resets)
         self.assertEqual(resets, 1)
 
+    def test_dictionary_mismatch_out_of_range(self):
+        decoder = StreamingDecoder(reporter=main.Reporter)
+        tokens = [
+            int(ControlToken.BOS),
+            int(ControlToken.RST),
+            int(ControlToken.SYNC),
+            65,
+            999,
+            int(ControlToken.EOS),
+        ]
+        with self.assertRaises(DictionaryMismatch):
+            decoder.decode(tokens)
+        resets = main.Reporter.report('sync_resets')
+        print('Sync resets:', resets)
+        self.assertEqual(resets, 1)
+
     def test_exception_hierarchy(self):
         self.assertTrue(issubclass(DictionaryMismatch, SyncError))
 

--- a/tests/test_streaming_tokenizer.py
+++ b/tests/test_streaming_tokenizer.py
@@ -40,6 +40,15 @@ class TestStreamingTokenizer(unittest.TestCase):
         self.assertEqual(size, 257)
         self.assertEqual(longest, 2)
 
+    def test_invalid_token_raises_keyerror(self):
+        tokenizer = StreamingTokenizer(main.Reporter)
+        stream = [65, 66, 67]
+        tokens = tokenizer.encode(stream)
+        tokens.append(9999)
+        print('Corrupted tokens:', tokens)
+        with self.assertRaises(KeyError):
+            tokenizer.decode(tokens)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- validate dictionary indices in `DictionaryManager.decode`
- enforce next-index check in streaming decoder
- cover corrupted token cases in tokenizer and decoder tests

## Testing
- `pytest tests/test_streaming_tokenizer.py tests/test_error_cases.py`


------
https://chatgpt.com/codex/tasks/task_e_68c01352458083278b6b451e2b38a9c1