### PR TITLE
Support persistent dictionaries and decoder mutation metrics

### DIFF
--- a/poted/decoder.py
+++ b/poted/decoder.py
@@ -1,6 +1,7 @@
 class StreamingDecoder:
-    def __init__(self, reporter=None):
+    def __init__(self, reporter=None, persistent=False):
         self._reporter = reporter
+        self._mode = 'persistent' if persistent else 'volatile'
         self._reset_state()
 
     def _reset_state(self):
@@ -17,24 +18,26 @@ class StreamingDecoder:
         token = Token(self._next)
         self._rev_dict[int(token)] = seq
         self._next += 1
+        if self._reporter:
+            count = self._reporter.report('decoder_mutations') or 0
+            self._reporter.report(
+                'decoder_mutations',
+                'Number of decoder dictionary mutations',
+                count + 1,
+            )
 
     def decode(self, tokens):
         from .core import Token
         from .control import ControlToken
         from .validator import ProtocolValidator
         ProtocolValidator.validate(tokens)
+        if self._mode == 'volatile':
+            self._reset_state()
         result = []
         prev = None
         for t in tokens:
             if t == int(ControlToken.RST):
                 self._reset_state()
-                if self._reporter:
-                    count = self._reporter.report('decoder_mutations') or 0
-                    self._reporter.report(
-                        'decoder_mutations',
-                        'Number of decoder state resets',
-                        count + 1,
-                    )
                 prev = None
                 continue
             if t in (
@@ -76,4 +79,6 @@ class StreamingDecoder:
             current = self._reporter.report('max_memory_bytes') or 0
             if memory > current:
                 self._reporter.report('max_memory_bytes', 'Maximum memory usage in bytes', memory)
+        if self._mode == 'volatile':
+            self._reset_state()
         return output

--- a/poted/validator.py
+++ b/poted/validator.py
@@ -9,9 +9,12 @@ class ProtocolValidator:
             raise ValueError('Missing BOS')
         if tokens[-1] != int(ControlToken.EOS):
             raise ValueError('Missing EOS')
-        if len(tokens) < 3 or tokens[1] != int(ControlToken.RST):
-            raise ValueError('Missing RST after BOS')
-        if tokens[2] != int(ControlToken.SYNC):
-            raise ValueError('Missing SYNC after RST')
+        if len(tokens) < 3:
+            raise ValueError('Token stream too short')
+        index = 1
+        if tokens[1] == int(ControlToken.RST):
+            index = 2
+        if tokens[index] != int(ControlToken.SYNC):
+            raise ValueError('Missing SYNC after BOS')
         Reporter.report('validated_tokens', 'Number of tokens validated', len(tokens))
         return True

--- a/tests/test_decoder_learning.py
+++ b/tests/test_decoder_learning.py
@@ -22,10 +22,11 @@ class TestStreamingDecoderLearning(unittest.TestCase):
         tokens = tokens1[:-1] + tokens2[1:]
         decoded = decoder.decode(tokens)
         self.assertEqual(decoded, stream1 + stream2)
-        self.assertEqual(main.Reporter.report('decoder_mutations'), 2)
+        mutations = main.Reporter.report('decoder_mutations')
+        self.assertEqual(mutations, 4)
         print('Combined tokens:', tokens)
         print('Decoded stream:', decoded)
-        print('Decoder mutations metric:', main.Reporter.report('decoder_mutations'))
+        print('Decoder mutations metric:', mutations)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- Allow optional persistent dictionaries across streams
- Teach StreamingDecoder to track dictionary mutations
- Relax protocol validation for optional RST tokens

## Testing
- `pytest tests/test_dictionary_persistence.py -q`
- `pytest tests/test_decoder_learning.py -q`
- `pytest tests/test_control_tokens.py -q`
- `pytest tests/test_streaming_tokenizer.py -q`
- `pytest tests/test_pipeline_roundtrip.py -q`
- `pip install hypothesis >/tmp/pip.log && tail -n 20 /tmp/pip.log`
- `pytest tests/test_roundtrip_properties.py -q`
- `pytest tests/test_poted_integrity.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c01b510e50832795345b423853e230