### PR TITLE
Add PoTED quickstart and array/tensor support

### DIFF
--- a/FAILEDTESTS.md
+++ b/FAILEDTESTS.md
@@ -1,2 +1,2 @@
-- [ ] PoTED roundtrip for numpy arrays: JsonSerializer raises TypeError
-- [ ] PoTED roundtrip for torch tensors: JsonSerializer raises TypeError
+- [solved] PoTED roundtrip for numpy arrays: JsonSerializer raises TypeError
+- [solved] PoTED roundtrip for torch tensors: JsonSerializer raises TypeError

--- a/README.md
+++ b/README.md
@@ -1,1 +1,66 @@
 # mymarble
+
+## Quickstart with PoTED
+
+```python
+from poted.poted import PoTED
+from main import Reporter
+
+engine = PoTED(reporter=Reporter)
+
+data = {"numbers": [1, 2, 3], "nested": {"flag": True}}
+tensor = engine(data)
+result = engine.decode(tensor)
+```
+
+```python
+import numpy as np
+import torch
+from poted.poted import PoTED
+
+engine = PoTED()
+
+tensor_np = engine(np.array([1, 2, 3]))
+roundtrip_np = engine.decode(tensor_np)
+
+tensor_torch = engine(torch.tensor([1, 2, 3]))
+roundtrip_torch = engine.decode(tensor_torch)
+```
+
+## Configuration options
+
+`PoTED` accepts several options:
+
+- `Lw`, `Le`, `Lu`: limits for dictionary and token sizes.
+- `mode`: `'instance'` or `'portable'`.
+- `device`: target device for tensors, e.g. `'cpu'` or `'cuda'`.
+- `persistent`: keep dictionary state across calls.
+- `serializer`, `tokenizer`, `decoder`, `tensor_builder`: custom components.
+- `reporter`: metrics collector.
+
+These can also be overridden per call:
+
+```python
+tensor = engine(data, mode="portable")
+restored = engine.decode(tensor, device="cpu")
+```
+
+## Reporter metrics
+
+Metrics are recorded automatically:
+
+- `total_tokens`
+- `compression_ratio`
+- `tensor_shape`
+- `encode_calls`
+- `decode_calls`
+- `sync_resets`
+- `roundtrip_failures`
+
+Query metrics via the reporter:
+
+```python
+from main import Reporter
+print(Reporter.report(["total_tokens", "compression_ratio", "tensor_shape"]))
+```
+

--- a/poted/pipeline.py
+++ b/poted/pipeline.py
@@ -4,19 +4,44 @@ from poted.tensor import TensorBuilder
 class JsonSerializer:
     def serialize(self, obj):
         import json
-        data = json.dumps(obj, separators=(",", ":"), sort_keys=True)
-        return data.encode('utf-8')
+        import numpy as np
+        import torch
+
+        def default(o):
+            if isinstance(o, np.ndarray):
+                return {"__ndarray__": o.tolist(), "dtype": str(o.dtype)}
+            if isinstance(o, torch.Tensor):
+                return {"__torch_tensor__": o.tolist(), "dtype": str(o.dtype)}
+            raise TypeError(
+                f"Object of type {type(o).__name__} is not JSON serializable"
+            )
+
+        data = json.dumps(obj, separators=(",", ":"), sort_keys=True, default=default)
+        return data.encode("utf-8")
 
     def deserialize(self, stream):
         import json
-        text = stream.decode('utf-8')
-        return json.loads(text)
+        import numpy as np
+        import torch
 
+        def object_hook(d):
+            if "__ndarray__" in d:
+                return np.array(d["__ndarray__"], dtype=d.get("dtype"))
+            if "__torch_tensor__" in d:
+                dtype_name = d.get("dtype", "float")
+                dtype = getattr(torch, dtype_name.split(".")[-1])
+                return torch.tensor(d["__torch_tensor__"], dtype=dtype)
+            return d
+
+        text = stream.decode("utf-8")
+        return json.loads(text, object_hook=object_hook)
 
 
 class PoTEDPipeline:
-    def __init__(self, serializer, tokenizer, tensor_builder, reporter=None, mode='instance'):
-        if mode not in ('portable', 'instance'):
+    def __init__(
+        self, serializer, tokenizer, tensor_builder, reporter=None, mode="instance"
+    ):
+        if mode not in ("portable", "instance"):
             raise ValueError("mode must be 'portable' or 'instance'")
         self._serializer = serializer
         self._tokenizer = tokenizer
@@ -25,9 +50,9 @@ class PoTEDPipeline:
         self._mode = mode
 
     def encode(self, obj):
-        if self._mode == 'portable':
+        if self._mode == "portable":
             dictionary = self._tokenizer._manager.export()
-            payload = {'dictionary': dictionary, 'payload': obj}
+            payload = {"dictionary": dictionary, "payload": obj}
             stream = self._serializer.serialize(payload)
         else:
             stream = self._serializer.serialize(obj)
@@ -35,15 +60,17 @@ class PoTEDPipeline:
         tensor = self._tensor_builder.to_tensor(tokens)
         if self._reporter:
             total = len(tokens)
-            self._reporter.report('total_tokens', 'Total number of tokens', total)
+            self._reporter.report("total_tokens", "Total number of tokens", total)
             ratio = len(tokens) / len(stream) if stream else 0
-            self._reporter.report('compression_ratio', 'Token count to byte length ratio', ratio)
+            self._reporter.report(
+                "compression_ratio", "Token count to byte length ratio", ratio
+            )
         return tensor
 
     def decode(self, tensor):
         tokens = self._tensor_builder.to_tokens(tensor)
         stream = self._tokenizer.detokenize(tokens)
         obj = self._serializer.deserialize(stream)
-        if self._mode == 'portable' and isinstance(obj, dict) and 'payload' in obj:
-            return obj['payload']
+        if self._mode == "portable" and isinstance(obj, dict) and "payload" in obj:
+            return obj["payload"]
         return obj

--- a/tests/test_poted_end_to_end.py
+++ b/tests/test_poted_end_to_end.py
@@ -13,8 +13,13 @@ import main
 from poted.poted import PoTED
 
 json_strategy = st.recursive(
-    st.none() | st.booleans() | st.integers() | st.floats(allow_nan=False, allow_infinity=False) | st.text(),
-    lambda children: st.lists(children, max_size=5) | st.dictionaries(st.text(), children, max_size=5),
+    st.none()
+    | st.booleans()
+    | st.integers()
+    | st.floats(allow_nan=False, allow_infinity=False)
+    | st.text(),
+    lambda children: st.lists(children, max_size=5)
+    | st.dictionaries(st.text(), children, max_size=5),
     max_leaves=20,
 )
 
@@ -27,44 +32,44 @@ class TestPoTEDEndToEnd(unittest.TestCase):
         main.Reporter._metrics = {}
         tensor = self.engine(obj)
         result = self.engine.decode(tensor)
-        print('Roundtrip input:', obj)
-        print('Roundtrip tensor:', tensor)
-        print('Roundtrip result:', result)
-        total = main.Reporter.report('total_tokens')
-        ratio = main.Reporter.report('compression_ratio')
-        shape = main.Reporter.report('tensor_shape')
-        print('Reporter metrics total_tokens:', total)
-        print('Reporter metrics compression_ratio:', ratio)
-        print('Reporter metrics tensor_shape:', shape)
+        print("Roundtrip input:", obj)
+        print("Roundtrip tensor:", tensor)
+        print("Roundtrip result:", result)
+        total = main.Reporter.report("total_tokens")
+        ratio = main.Reporter.report("compression_ratio")
+        shape = main.Reporter.report("tensor_shape")
+        print("Reporter metrics total_tokens:", total)
+        print("Reporter metrics compression_ratio:", ratio)
+        print("Reporter metrics tensor_shape:", shape)
         self.assertIsNotNone(total)
         self.assertIsNotNone(ratio)
         self.assertIsNotNone(shape)
         return result
 
     def test_roundtrip_dict(self):
-        obj = {'a': 1, 'b': [1, 2, 3]}
+        obj = {"a": 1, "b": [1, 2, 3]}
         result = self._roundtrip(obj)
         self.assertEqual(result, obj)
 
     def test_roundtrip_list(self):
-        obj = [1, 2, {'c': 3}]
+        obj = [1, 2, {"c": 3}]
         result = self._roundtrip(obj)
         self.assertEqual(result, obj)
 
     def test_roundtrip_nested(self):
-        obj = {'x': [1, {'y': [2, 3]}, 4]}
+        obj = {"x": [1, {"y": [2, 3]}, 4]}
         result = self._roundtrip(obj)
         self.assertEqual(result, obj)
 
-    def test_numpy_tensor_error(self):
+    def test_roundtrip_numpy_array(self):
         np_array = np.array([1, 2, 3])
-        with self.assertRaises(TypeError):
-            self.engine(np_array)
+        result = self._roundtrip(np_array)
+        self.assertTrue(np.array_equal(result, np_array))
 
-    def test_torch_tensor_error(self):
+    def test_roundtrip_torch_tensor(self):
         torch_tensor = torch.tensor([1, 2, 3])
-        with self.assertRaises(TypeError):
-            self.engine(torch_tensor)
+        result = self._roundtrip(torch_tensor)
+        self.assertTrue(torch.equal(result, torch_tensor))
 
     @settings(max_examples=10)
     @given(json_strategy)


### PR DESCRIPTION
## Summary
- document Quickstart with PoTED, configuration options, and reporter metrics
- enable JsonSerializer to roundtrip NumPy arrays and torch tensors
- expand tests to cover array and tensor serialization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c02218c1d88327ac48f896fb1a3b07