### PR TITLE
Track integrity per tensor for independent decoding

### DIFF
--- a/tests/test_multiple_roundtrips.py
+++ b/tests/test_multiple_roundtrips.py
@@ -1,0 +1,26 @@
+import unittest
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+import main
+from poted.poted import PoTED
+
+
+class TestMultipleRoundtrips(unittest.TestCase):
+    def setUp(self):
+        main.Reporter._metrics = {}
+
+    def test_out_of_order_decoding(self):
+        engine = PoTED(reporter=main.Reporter)
+        tensor_a = engine({'msg': 'A'})
+        tensor_b = engine({'msg': 'B'})
+        result_a = engine.decode(tensor_a)
+        result_b = engine.decode(tensor_b)
+        print('Decoded objects:', result_a, result_b)
+        self.assertEqual(result_a, {'msg': 'A'})
+        self.assertEqual(result_b, {'msg': 'B'})
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- maintain integrity hashes for every encoded tensor
- verify stream and dictionary against stored hashes during decode
- test decoding tensors out of order

## Testing
- `python tests/test_dictionary_hash.py`
- `python tests/test_poted_integrity.py`
- `python -m unittest tests.test_poted_end_to_end`
- `python tests/test_multiple_roundtrips.py`


------
https://chatgpt.com/codex/tasks/task_e_68c02c77532483278800b1c8ea0c2252