### PR TITLE
Fix reporter restoration for overridden components

### DIFF
--- a/poted/poted.py
+++ b/poted/poted.py
@@ -67,6 +67,7 @@ class PoTED:
                 'Le': getattr(self._tensor_builder, '_Le', None),
                 'Lu': getattr(self._tensor_builder, '_Lu', None),
             }
+            override_reporters = {}
             try:
                 if serializer is not None:
                     self._serializer = serializer
@@ -81,8 +82,10 @@ class PoTED:
                     self._reporter = reporter
                     self._tokenizer._manager._reporter = reporter
                     if hasattr(self._decoder, '_reporter'):
+                        override_reporters[self._decoder] = self._decoder._reporter
                         self._decoder._reporter = reporter
                     if hasattr(self._tensor_builder, '_reporter'):
+                        override_reporters[self._tensor_builder] = self._tensor_builder._reporter
                         self._tensor_builder._reporter = reporter
                 if 'mode' in config:
                     self._mode = config['mode']
@@ -116,6 +119,9 @@ class PoTED:
                     self._decoder._reporter = original['reporter']
                 if hasattr(self._tensor_builder, '_reporter'):
                     self._tensor_builder._reporter = original['reporter']
+                for obj, rep in override_reporters.items():
+                    if hasattr(obj, '_reporter'):
+                        obj._reporter = rep
         return manager()
     def _instantiate_reporter(self, reporter):
         if reporter is None:

--- a/tests/test_override_reporter.py
+++ b/tests/test_override_reporter.py
@@ -1,0 +1,46 @@
+import unittest
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+
+from poted.poted import PoTED
+
+
+class DummyReporter:
+    def report(self, *args, **kwargs):
+        pass
+
+
+class DummyDecoder:
+    def __init__(self, reporter):
+        self._reporter = reporter
+
+
+class DummyBuilder:
+    def __init__(self, reporter):
+        self._reporter = reporter
+
+
+class TestOverrideReporter(unittest.TestCase):
+    def setUp(self):
+        self.original = DummyReporter()
+        self.temporary = DummyReporter()
+        self.decoder = DummyDecoder(self.original)
+        self.builder = DummyBuilder(self.original)
+        self.poted = PoTED(reporter=self.original)
+
+    def test_restore_reporter(self):
+        with self.poted._override(
+            decoder=self.decoder, tensor_builder=self.builder, reporter=self.temporary
+        ):
+            self.assertIs(self.decoder._reporter, self.temporary)
+            self.assertIs(self.builder._reporter, self.temporary)
+        print('Decoder reporter after context:', self.decoder._reporter)
+        print('Builder reporter after context:', self.builder._reporter)
+        self.assertIs(self.decoder._reporter, self.original)
+        self.assertIs(self.builder._reporter, self.original)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure temporary reporter overrides for custom decoders/tensor builders are reverted
- add regression test verifying reporters are restored after override context

## Testing
- `pytest tests/test_override_reporter.py -q`
- `pytest tests/test_poted_end_to_end.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c03095b2288327936841cd0eeca584