### PR TITLE
Fix persistent PoTED call decode snapshot handling

### DIFF
--- a/poted/poted.py
+++ b/poted/poted.py
@@ -264,6 +264,16 @@ class PoTED:
             stream_hash = checker.hash_stream(tokens)
             dict_hash = checker.hash_dictionary(self._tokenizer._manager)
             self._integrity_states[stream_hash] = dict_hash
+            if self._dictionary._mode == 'persistent':
+                self._dictionary_snapshots[stream_hash] = (
+                    self._dictionary._rev_dict.copy(),
+                    self._dictionary._next,
+                )
+                self._reporter.report(
+                    'snapshot_count',
+                    'Number of active dictionary snapshots',
+                    len(self._dictionary_snapshots),
+                )
             tensor = self._tensor_builder.to_tensor(tokens)
             total = len(tokens)
             ratio = len(tokens) / len(stream) if stream else 0

--- a/tests/test_persistent_call_decode.py
+++ b/tests/test_persistent_call_decode.py
@@ -1,0 +1,23 @@
+import unittest
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+import main
+from poted.poted import PoTED
+
+
+class TestPersistentCallDecode(unittest.TestCase):
+    def setUp(self):
+        main.Reporter._metrics = {}
+
+    def test_call_roundtrip(self):
+        engine = PoTED(reporter=main.Reporter, persistent=True)
+        tensor = engine({'msg': 'x'})
+        result = engine.decode(tensor)
+        print('Call decode result:', result)
+        self.assertEqual(result, {'msg': 'x'})
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- snapshot persistent dictionary state for `PoTED.__call__` invocations
- add regression test ensuring persistent call roundtrip succeeds

## Testing
- `pytest tests/test_persistent_call_decode.py -q -s`
- `pytest tests/test_persistent_poted_decode.py -q -s`


------
https://chatgpt.com/codex/tasks/task_e_68c117065e288327bdc7a53781ca31ea