### PR TITLE
Preserve tensor device and grad in serializer

### DIFF
--- a/poted/pipeline.py
+++ b/poted/pipeline.py
@@ -11,7 +11,12 @@ class JsonSerializer:
             if isinstance(o, np.ndarray):
                 return {"__ndarray__": o.tolist(), "dtype": str(o.dtype)}
             if isinstance(o, torch.Tensor):
-                return {"__torch_tensor__": o.tolist(), "dtype": str(o.dtype)}
+                return {
+                    "__torch_tensor__": o.tolist(),
+                    "dtype": str(o.dtype),
+                    "device": str(o.device),
+                    "requires_grad": o.requires_grad,
+                }
             raise TypeError(
                 f"Object of type {type(o).__name__} is not JSON serializable"
             )
@@ -30,7 +35,14 @@ class JsonSerializer:
             if "__torch_tensor__" in d:
                 dtype_name = d.get("dtype", "float")
                 dtype = getattr(torch, dtype_name.split(".")[-1])
-                return torch.tensor(d["__torch_tensor__"], dtype=dtype)
+                device = torch.device(d.get("device", "cpu"))
+                requires_grad = d.get("requires_grad", False)
+                return torch.tensor(
+                    d["__torch_tensor__"],
+                    dtype=dtype,
+                    device=device,
+                    requires_grad=requires_grad,
+                )
             return d
 
         text = stream.decode("utf-8")

--- a/tests/test_poted_end_to_end.py
+++ b/tests/test_poted_end_to_end.py
@@ -67,9 +67,14 @@ class TestPoTEDEndToEnd(unittest.TestCase):
         self.assertTrue(np.array_equal(result, np_array))
 
     def test_roundtrip_torch_tensor(self):
-        torch_tensor = torch.tensor([1, 2, 3])
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        torch_tensor = torch.tensor(
+            [1.0, 2.0, 3.0], device=device, requires_grad=True
+        )
         result = self._roundtrip(torch_tensor)
         self.assertTrue(torch.equal(result, torch_tensor))
+        self.assertEqual(result.device, torch_tensor.device)
+        self.assertEqual(result.requires_grad, torch_tensor.requires_grad)
 
     @settings(max_examples=10)
     @given(json_strategy)


### PR DESCRIPTION
## Summary
- store device and requires_grad when serializing torch tensors
- restore tensor metadata during deserialization
- verify roundtrip keeps tensor device and gradient flag

## Testing
- `pytest tests/test_pipeline_roundtrip.py::TestPoTEDPipelineRoundtrip::test_roundtrip tests/test_poted_end_to_end.py::TestPoTEDEndToEnd::test_roundtrip_torch_tensor -q`

------
https://chatgpt.com/codex/tasks/task_e_68c1182e986883278b536442a13588eb