### PR TITLE
Implement neuron loss tracking with LossTracker

### DIFF
--- a/network/learning.py
+++ b/network/learning.py
@@ -1,0 +1,91 @@
+"""Utilities for tracking learning metrics in neural graphs.
+
+The :class:`LossTracker` class maintains per-neuron loss statistics without
+introducing any module level imports.  A reporter object is expected to be
+provided so that metrics are recorded globally.
+"""
+
+
+class LossTracker:
+    """Track rolling loss metrics for neurons.
+
+    Parameters
+    ----------
+    reporter : object
+        Instance providing a ``report`` method compatible with
+        :class:`main.Reporter`.  Metrics are emitted through this object.
+    zero : object, optional
+        Tensor-like object used for initialising averages.  Defaults to ``0``.
+    """
+
+    def __init__(self, reporter, zero=0):
+        self._reporter = reporter
+        self._zero = zero
+        self._stats = {}
+
+    def update_loss(self, neuron, new_path_losses):
+        """Update loss history for ``neuron``.
+
+        This implements the recurrence from Eq. (0.1) by maintaining both the
+        cumulative path count :math:`m_{v\to}^t` and a rolling average of the
+        provided path losses over time steps.  The neuron's
+        ``last_local_loss`` field is updated with the new rolling average and
+        the update is recorded via :func:`Reporter.report`.
+
+        Parameters
+        ----------
+        neuron : :class:`network.entities.Neuron`
+            The neuron whose loss statistics are updated.
+        new_path_losses : iterable
+            Iterable of loss tensors representing the loss along each outgoing
+            path for the current time step.
+        """
+        losses = list(new_path_losses)
+        path_count = len(losses)
+        total_loss = self._zero
+        for loss in losses:
+            total_loss = total_loss + loss
+        if path_count:
+            mean_loss = total_loss / path_count
+        else:
+            mean_loss = self._zero
+        stats = self._stats.get(neuron)
+        if stats is None:
+            stats = {"t": 0, "avg": self._zero, "m": 0}
+        stats["t"] += 1
+        stats["m"] += path_count
+        t = stats["t"]
+        stats["avg"] = ((stats["avg"] * (t - 1)) + mean_loss) / t
+        self._stats[neuron] = stats
+        neuron.record_local_loss(stats["avg"])
+        count = self._reporter.report("loss_updates") or 0
+        self._reporter.report(
+            "loss_updates",
+            "Number of loss updates performed",
+            count + 1,
+        )
+        self._reporter.report(
+            f"neuron_{id(neuron)}_path_count",
+            "Total paths processed for neuron",
+            stats["m"],
+        )
+        self._reporter.report(
+            f"neuron_{id(neuron)}_rolling_loss",
+            "Rolling average of path losses for neuron",
+            stats["avg"],
+        )
+        return stats["avg"]
+
+    def get_stats(self, neuron):
+        """Return a dictionary snapshot of statistics for ``neuron``."""
+        stats = self._stats.get(neuron)
+        if stats is None:
+            return {"t": 0, "avg": self._zero, "m": 0}
+        return stats.copy()
+
+    def reset(self, neuron=None):
+        """Reset statistics for ``neuron`` or all neurons if ``None``."""
+        if neuron is None:
+            self._stats = {}
+        else:
+            self._stats.pop(neuron, None)

--- a/tests/test_loss_tracker.py
+++ b/tests/test_loss_tracker.py
@@ -1,0 +1,29 @@
+import unittest
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+import main
+from network.entities import Neuron
+from network.learning import LossTracker
+
+
+class TestLossTracker(unittest.TestCase):
+    def setUp(self):
+        main.Reporter._metrics = {}
+
+    def test_loss_tracking(self):
+        reporter = main.Reporter
+        neuron = Neuron()
+        tracker = LossTracker(reporter)
+        tracker.update_loss(neuron, [1, 3])
+        self.assertEqual(neuron.last_local_loss, 2)
+        tracker.update_loss(neuron, [3, 5])
+        self.assertEqual(neuron.last_local_loss, 3)
+        self.assertEqual(reporter.report('loss_updates'), 2)
+        print('Stats after updates:', tracker.get_stats(neuron))
+        print('Loss updates metric:', reporter.report('loss_updates'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `LossTracker` class for per-neuron rolling loss statistics and path counts
- update reporter metrics for each loss update
- add unit test validating loss tracking behavior

## Testing
- `python -m pytest tests/test_loss_tracker.py tests/test_network_graph.py -q -s`


------
https://chatgpt.com/codex/tasks/task_e_68c1198306f083278aeef37c56f22201