### PR TITLE
Add path selection mechanism to neural graph

### DIFF
--- a/network/path_selector.py
+++ b/network/path_selector.py
@@ -1,0 +1,79 @@
+class PathSelector:
+    r"""Select outgoing synapses based on a configurable scoring function.
+
+    The selector evaluates each candidate synapse using a latency weighted
+    scoring function as defined by Eq. (0.2).  The default implementation of
+    this equation is::
+
+        f = w(\lambda_e) * \lambda_e + |(L_v + c_e) - L^*| + \sum_i h_i
+
+    where ``w(\lambda_e)`` is a latency weighting function, ``\lambda_e`` the
+    synapse latency, ``L_v`` the neuron's last recorded local loss, ``c_e`` a
+    synapse cost term, ``L^*`` the global loss target, and ``h_i`` additional
+    penalties supplied via hooks.  The synapse (or sequence) with the minimum
+    score is returned.
+
+    Parameters
+    ----------
+    latency_weight : float or callable, optional
+        Weight applied to latency.  If a callable is provided it is invoked with
+        the synapse and should return a numeric weight.  Defaults to ``1.0``.
+    loss_hooks : iterable of callables, optional
+        Additional scoring terms.  Each hook is called as
+        ``hook(neuron, synapse, state)`` and should return a numeric penalty.
+    reporter : object, optional
+        Object providing a ``report`` method compatible with
+        :class:`main.Reporter`.  If supplied, selection metrics are recorded
+        through it.
+    """
+
+    def __init__(self, latency_weight=1.0, loss_hooks=None, reporter=None):
+        if callable(latency_weight):
+            self._latency_weight = latency_weight
+        else:
+            self._latency_weight = lambda synapse: latency_weight
+        self._loss_hooks = list(loss_hooks) if loss_hooks else []
+        self._reporter = reporter
+        self._selection_count = 0
+
+    def add_hook(self, hook):
+        """Register an additional loss hook."""
+        self._loss_hooks.append(hook)
+
+    def _score(self, neuron, synapse, state):
+        latency = getattr(synapse, "lambda_e", 0)
+        weight = self._latency_weight(synapse)
+        local_loss = getattr(neuron, "last_local_loss", 0)
+        syn_cost = getattr(synapse, "c_e", 0)
+        target = state.get("global_loss_target", 0)
+        loss_term = abs((local_loss + syn_cost) - target)
+        score = weight * latency + loss_term
+        for hook in self._loss_hooks:
+            score += hook(neuron, synapse, state)
+        return score
+
+    def select_path(self, neuron, graph_state):
+        """Return the outgoing synapse minimising the scoring function."""
+        outgoing = graph_state.get("outgoing_synapses") or graph_state.get("outgoing") or []
+        best_synapse = None
+        best_score = None
+        for synapse in outgoing:
+            score = self._score(neuron, synapse, graph_state)
+            if best_score is None or score < best_score:
+                best_score = score
+                best_synapse = synapse
+        if self._reporter is not None:
+            self._selection_count += 1
+            count = self._reporter.report("path_selector_calls") or 0
+            self._reporter.report(
+                "path_selector_calls",
+                "Number of path selections performed",
+                count + 1,
+            )
+            if best_score is not None:
+                self._reporter.report(
+                    "path_selector_last_score",
+                    "Score of last selected path",
+                    best_score,
+                )
+        return best_synapse

--- a/tests/test_path_selector.py
+++ b/tests/test_path_selector.py
@@ -1,0 +1,45 @@
+import unittest
+import sys
+import pathlib
+import torch
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+from network.entities import Neuron, Synapse
+from network.path_selector import PathSelector
+from network.graph import Graph
+
+
+class TestPathSelector(unittest.TestCase):
+    def setUp(self):
+        self.zero = torch.tensor(0.0)
+
+    def _build_graph(self, selector, synapses):
+        g = Graph(path_selector=selector)
+        n1 = Neuron(zero=self.zero)
+        n1.record_local_loss(self.zero)
+        n2 = Neuron(zero=self.zero)
+        g.add_neuron('n1', n1)
+        g.add_neuron('n2', n2)
+        for idx, syn in enumerate(synapses, start=1):
+            g.add_synapse(f's{idx}', 'n1', 'n2', syn)
+        return g
+
+    def test_select_lowest_score(self):
+        selector = PathSelector()
+        s1 = Synapse(lambda_e=torch.tensor(5.0), c_e=torch.tensor(0.0), zero=self.zero)
+        s2 = Synapse(lambda_e=torch.tensor(1.0), c_e=torch.tensor(10.0), zero=self.zero)
+        g = self._build_graph(selector, [s1, s2])
+        result = g.forward(global_loss_target=self.zero)
+        self.assertIs(result['n1'], s1)
+
+    def test_latency_weighting(self):
+        selector = PathSelector(latency_weight=10.0)
+        s1 = Synapse(lambda_e=torch.tensor(5.0), c_e=torch.tensor(0.0), zero=self.zero)
+        s2 = Synapse(lambda_e=torch.tensor(1.0), c_e=torch.tensor(10.0), zero=self.zero)
+        g = self._build_graph(selector, [s1, s2])
+        result = g.forward(global_loss_target=self.zero)
+        self.assertIs(result['n1'], s2)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- introduce `PathSelector` scoring synapses via latency and loss terms with extensible hooks
- integrate selector into `Graph.forward` so each neuron chooses the optimal path
- cover new functionality with unit tests for default and weighted latency strategies

## Testing
- `pytest tests/test_network_graph.py tests/test_path_selector.py tests/test_loss_tracker.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c11aa62afc8327831986a8d28ed2c4