### PR TITLE
Add tests for graph entities, path selection, latency metrics, and loss tracker

### DIFF
--- a/tests/test_graph_entities.py
+++ b/tests/test_graph_entities.py
@@ -1,0 +1,43 @@
+import unittest
+import sys
+import pathlib
+import time
+import torch
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+import main
+from network.entities import Neuron, Synapse
+from network.graph import Graph
+from network.latency import LatencyEstimator
+
+
+class TestGraphEntities(unittest.TestCase):
+    def setUp(self):
+        main.Reporter._metrics = {}
+        self.zero = torch.tensor(0.0)
+
+    def test_tensor_states_and_latency(self):
+        estimator = LatencyEstimator(reporter=main.Reporter, zero=self.zero)
+        graph = Graph(latency_estimator=estimator, reporter=main.Reporter)
+        n1 = Neuron(zero=self.zero)
+        n2 = Neuron(zero=self.zero)
+        s1 = Synapse(zero=self.zero)
+        graph.add_neuron("n1", n1)
+        graph.add_neuron("n2", n2)
+        graph.add_synapse("s1", "n1", "n2", s1)
+        self.assertEqual(n1.lambda_v, self.zero)
+        self.assertEqual(s1.lambda_e, self.zero)
+        graph.forward(global_loss_target=self.zero)
+        time.sleep(0.01)
+        graph.forward(global_loss_target=self.zero)
+        print("Neuron latency after update:", n1.lambda_v)
+        print("Synapse latency after update:", s1.lambda_e)
+        self.assertGreater(n1.lambda_v.item(), 0)
+        self.assertGreater(s1.lambda_e.item(), 0)
+        snapshot = n1.to_dict()
+        print("Neuron state snapshot:", snapshot)
+        self.assertIn("activation", snapshot)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_latency_reporting.py
+++ b/tests/test_latency_reporting.py
@@ -1,0 +1,37 @@
+import unittest
+import sys
+import pathlib
+import time
+import torch
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+import main
+from network.entities import Neuron, Synapse
+from network.latency import LatencyEstimator
+
+
+class TestLatencyReporting(unittest.TestCase):
+    def setUp(self):
+        main.Reporter._metrics = {}
+        self.zero = torch.tensor(0.0)
+
+    def test_latency_metrics(self):
+        estimator = LatencyEstimator(reporter=main.Reporter, zero=self.zero)
+        neuron = Neuron(zero=self.zero)
+        synapse = Synapse(zero=self.zero)
+        # first update to initialise timestamps
+        estimator.update("n1", neuron, {"s1": synapse})
+        time.sleep(0.01)
+        estimator.update("n1", neuron, {"s1": synapse})
+        n_metric = main.Reporter.report("latency_neuron_n1")
+        s_metric = main.Reporter.report("latency_synapse_s1")
+        print("Reported neuron latency:", n_metric)
+        print("Reported synapse latency:", s_metric)
+        self.assertGreater(n_metric.item(), 0)
+        self.assertGreater(s_metric.item(), 0)
+        print("Synapse lambda and cost:", synapse.lambda_e, synapse.c_e)
+        self.assertEqual(synapse.lambda_e, synapse.c_e)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_loss_tracker.py
+++ b/tests/test_loss_tracker.py
@@ -39,6 +39,18 @@ class TestLossTracker(unittest.TestCase):
         self.assertFalse(avg.requires_grad)
         self.assertFalse(neuron.last_local_loss.requires_grad)
 
+    def test_eq_01_updates(self):
+        reporter = main.Reporter
+        neuron = Neuron()
+        tracker = LossTracker(reporter, zero=torch.tensor(0.0))
+        tracker.update_loss(neuron, [torch.tensor(1.0), torch.tensor(3.0)])
+        tracker.update_loss(neuron, [torch.tensor(3.0), torch.tensor(5.0)])
+        stats = tracker.get_stats(neuron)
+        print('Tracker stats:', stats)
+        self.assertEqual(stats['t'], 2)
+        self.assertEqual(stats['m'], 4)
+        self.assertAlmostEqual(stats['avg'].item(), 3.0, places=5)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_path_selection.py
+++ b/tests/test_path_selection.py
@@ -1,0 +1,31 @@
+import unittest
+import sys
+import pathlib
+import torch
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+import main
+from network.entities import Neuron, Synapse
+from network.path_selector import PathSelector
+
+
+class TestPathSelection(unittest.TestCase):
+    def setUp(self):
+        main.Reporter._metrics = {}
+        self.zero = torch.tensor(0.0)
+
+    def test_minimal_loss_path(self):
+        neuron = Neuron(zero=self.zero)
+        neuron.record_local_loss(torch.tensor(2.0))
+        s1 = Synapse(lambda_e=torch.tensor(1.0), c_e=torch.tensor(0.0), zero=self.zero)
+        s2 = Synapse(lambda_e=torch.tensor(0.1), c_e=torch.tensor(0.0), zero=self.zero)
+        selector = PathSelector(reporter=main.Reporter)
+        state = {"outgoing_synapses": [s1, s2], "global_loss_target": self.zero}
+        chosen = selector.select_path(neuron, state)
+        print("Path selector calls:", main.Reporter.report("path_selector_calls"))
+        print("Last path score:", main.Reporter.report("path_selector_last_score"))
+        self.assertIs(chosen, s2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add graph entity test ensuring tensor states and latency updates
- expand loss tracker tests verifying Eq.(0.1) statistics
- add path selection test checking minimal-loss path via Eq.(0.2)
- confirm latency reporter emits lambda and cost metrics

## Testing
- `pytest tests/test_graph_entities.py tests/test_loss_tracker.py tests/test_path_selection.py tests/test_latency_reporting.py -s -q`

------
https://chatgpt.com/codex/tasks/task_e_68c11fd1ea988327b0282ec3316a6f3d