### PR TITLE
feat: add soft and exact path selection

### DIFF
--- a/network/path_selector.py
+++ b/network/path_selector.py
@@ -77,3 +77,126 @@ class PathSelector:
                     best_score,
                 )
         return best_synapse
+
+    def _extract_cost(self, path):
+        """Return ``(sequence, cost)`` for ``path``.
+
+        ``path`` may either be a plain iterable of graph elements with an
+        associated ``cost`` attribute or a two-item iterable ``(sequence,
+        cost)``.  When no explicit cost is available the method falls back to
+        computing the cost using :class:`network.path_cost.PathCostCalculator`
+        with default parameters.  Imports are performed lazily inside the
+        method to honour the repository guidelines.
+        """
+
+        sequence = path
+        cost = None
+        if isinstance(path, (list, tuple)) and len(path) == 2:
+            sequence, cost = path
+        else:
+            cost = getattr(path, "cost", None)
+        if cost is None:
+            from .path_cost import PathCostCalculator  # local import
+            calculator = PathCostCalculator(self._reporter)
+            cost = calculator.compute_cost(sequence, 0, 0, 1, 1, 1)
+        return sequence, cost
+
+    def select_exact(self, neuron, paths):
+        r"""Return the minimal cost path and its sampled counterpart.
+
+        The method implements Eq. (1.3.1) by selecting the path ``S`` with the
+        lowest cost :math:`C(P)`.  As no stochastic sampling is performed, the
+        sampled path ``P`` is identical to ``S``.
+
+        Parameters
+        ----------
+        neuron : object
+            Neuron for which the selection is performed.  Used only for metric
+            reporting.
+        paths : iterable
+            Iterable of paths.  Each path may provide an explicit cost or will
+            be evaluated on demand.
+        """
+
+        best_index = None
+        best_cost = None
+        best_path = None
+        for idx, raw in enumerate(paths):
+            sequence, cost = self._extract_cost(raw)
+            if best_cost is None or cost < best_cost:
+                best_cost = cost
+                best_index = idx
+                best_path = sequence
+        sampled_path = best_path
+        if self._reporter is not None and best_cost is not None:
+            self._reporter.report(
+                f"neuron_{id(neuron)}_selected_path",
+                "Index of selected path for neuron",
+                best_index,
+            )
+            cost_detached = best_cost.detach() if hasattr(best_cost, "detach") else best_cost
+            self._reporter.report(
+                f"neuron_{id(neuron)}_sampled_path_cost",
+                "Cost of sampled path for neuron",
+                cost_detached,
+            )
+        return best_path, sampled_path
+
+    def select_soft(self, neuron, paths, R_v_star, T_sample):
+        r"""Stochastically select a path using a Gumbel-softmax scheme.
+
+        For each feasible path ``P`` the score
+        ``R(P) = exp((R_v_star - C(P)) / T_sample)`` is computed and
+        normalised into a categorical distribution.  A path is sampled from
+        this distribution using a Gumbel-softmax reparameterisation.  The
+        method returns both the best path ``S`` (minimal cost) and the sampled
+        full path ``P``.
+
+        Parameters
+        ----------
+        neuron : object
+            Neuron for which the selection is performed.
+        paths : iterable
+            Iterable of candidate paths.
+        R_v_star : tensor-like
+            Reference reward used in the exponent.
+        T_sample : tensor-like
+            Sampling temperature controlling exploration.
+        """
+
+        sequences = []
+        costs = []
+        for raw in paths:
+            sequence, cost = self._extract_cost(raw)
+            sequences.append(sequence)
+            costs.append(cost)
+        if not costs:
+            return None, None
+        import torch  # local import
+        from torch.nn.functional import gumbel_softmax  # local import
+
+        cost_tensors = [c if hasattr(c, "shape") else torch.tensor(c) for c in costs]
+        stacked = torch.stack(cost_tensors)
+        R_v_star_t = R_v_star if hasattr(R_v_star, "shape") else torch.tensor(R_v_star)
+        T_sample_t = T_sample if hasattr(T_sample, "shape") else torch.tensor(T_sample)
+        rewards = torch.exp((R_v_star_t - stacked) / T_sample_t)
+        probs = rewards / rewards.sum()
+        sample_one_hot = gumbel_softmax(torch.log(probs), tau=1.0, hard=True)
+        sampled_index = int(sample_one_hot.argmax().item())
+        best_index = int(torch.argmin(stacked).item())
+        sampled_path = sequences[sampled_index]
+        best_path = sequences[best_index]
+        sampled_cost = cost_tensors[sampled_index]
+        if self._reporter is not None:
+            self._reporter.report(
+                f"neuron_{id(neuron)}_selected_path",
+                "Index of selected path for neuron",
+                best_index,
+            )
+            cost_detached = sampled_cost.detach() if hasattr(sampled_cost, "detach") else sampled_cost
+            self._reporter.report(
+                f"neuron_{id(neuron)}_sampled_path_cost",
+                "Cost of sampled path for neuron",
+                cost_detached,
+            )
+        return best_path, sampled_path

--- a/tests/test_path_selector_extended.py
+++ b/tests/test_path_selector_extended.py
@@ -1,0 +1,43 @@
+import unittest
+import sys
+import pathlib
+import torch
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+import main
+from network.entities import Neuron
+from network.path_selector import PathSelector
+
+
+class DummyPath:
+    def __init__(self, name, cost):
+        self.name = name
+        self.cost = torch.tensor(cost)
+
+
+class TestExtendedPathSelector(unittest.TestCase):
+    def setUp(self):
+        main.Reporter._metrics = {}
+        self.neuron = Neuron()
+        self.selector = PathSelector(reporter=main.Reporter)
+
+    def test_select_exact(self):
+        paths = [DummyPath('a', 3.0), DummyPath('b', 1.0), DummyPath('c', 2.0)]
+        best, sampled = self.selector.select_exact(self.neuron, paths)
+        print('selected_path_metric', main.Reporter.report(f'neuron_{id(self.neuron)}_selected_path'))
+        print('sampled_cost_metric', main.Reporter.report(f'neuron_{id(self.neuron)}_sampled_path_cost'))
+        self.assertIs(best, paths[1])
+        self.assertIs(sampled, paths[1])
+
+    def test_select_soft(self):
+        torch.manual_seed(2)
+        paths = [DummyPath('a', 0.1), DummyPath('b', 2.0)]
+        best, sampled = self.selector.select_soft(self.neuron, paths, torch.tensor(0.0), torch.tensor(1.0))
+        print('selected_path_metric', main.Reporter.report(f'neuron_{id(self.neuron)}_selected_path'))
+        print('sampled_cost_metric', main.Reporter.report(f'neuron_{id(self.neuron)}_sampled_path_cost'))
+        self.assertIs(best, paths[0])
+        self.assertIs(sampled, paths[1])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend PathSelector with exact and soft path selection methods
- compute soft selection with Gumbel-softmax and record metrics per neuron
- test new selection behaviours

## Testing
- `pytest tests/test_path_selector.py tests/test_path_selection.py tests/test_path_selector_extended.py -s`


------
https://chatgpt.com/codex/tasks/task_e_68c12686b52c83278b06319386e9153a