### PR TITLE
Integrate entry sampling and path evaluation

### DIFF
--- a/tests/test_graph_forward.py
+++ b/tests/test_graph_forward.py
@@ -1,0 +1,45 @@
+import unittest
+import sys
+import pathlib
+import torch
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+from main import Reporter
+from network.entities import Neuron, Synapse
+from network.graph import Graph
+
+
+class TestGraphForward(unittest.TestCase):
+    def test_forward_pipeline(self):
+        torch.manual_seed(0)
+        zero = torch.tensor(0.0)
+        n1 = Neuron(zero=zero)
+        n2 = Neuron(zero=zero)
+        n1.phi_v = torch.tensor(1.0)
+        n2.phi_v = torch.tensor(-10.0)
+        n1.last_local_loss = torch.tensor(0.1)
+        n1.lambda_v = torch.tensor(0.2)
+        n2.last_local_loss = torch.tensor(0.0)
+        n2.lambda_v = torch.tensor(0.3)
+        s1 = Synapse(zero=zero)
+        s1.c_e = torch.tensor(0.2)
+        s1.lambda_e = torch.tensor(0.4)
+        Reporter._metrics = {}
+        g = Graph(reporter=Reporter)
+        g.add_neuron("n1", n1)
+        g.add_neuron("n2", n2)
+        g.add_synapse("s1", "n1", "n2", s1)
+        path = g.forward(
+            method="exact",
+            cost_params={"lambda_0": 0, "lambda_max": 1, "alpha": 1, "beta": 1, "T_heat": 1},
+        )
+        self.assertEqual(path[0], n1)
+        self.assertEqual(path[1], s1)
+        self.assertEqual(path[2], n2)
+        self.assertEqual(Reporter.report("entry_id"), "n1")
+        self.assertEqual(Reporter.report("path_id"), 0)
+        self.assertIsNotNone(Reporter.report("path_cost"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- track EntrySampler, PathCostCalculator and PathSelector within Graph
- implement path-based forward pass with cost/latency propagation and metrics
- add test covering forward pipeline integration

## Testing
- `python -m pytest tests/test_entry_sampler.py tests/test_path_cost.py tests/test_path_selector.py tests/test_network_graph.py tests/test_graph_forward.py`

------
https://chatgpt.com/codex/tasks/task_e_68c128a4e6c08327b1571dedaf3806db