### PR TITLE
Add probabilistic routing tests

### DIFF
--- a/tests/test_entry_sampler.py
+++ b/tests/test_entry_sampler.py
@@ -1,47 +1,80 @@
 import unittest
 import sys
 import pathlib
+from collections import defaultdict
+
 import torch
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+import main
 from network.entities import Neuron
 from network.graph import Graph
 from network.entry_sampler import EntrySampler
 
 
-class CapturingReporter:
-    def __init__(self):
-        self.calls = []
-
-    def report(self, *args):
-        self.calls.append(args)
+class ReporterAdapter:
+    def report(self, name, value):
+        main.Reporter.report(name, f"Entry sampler metric {name}", value)
 
 
 class TestEntrySampler(unittest.TestCase):
     def setUp(self):
         torch.manual_seed(0)
+        main.Reporter._metrics = {}
         self.zero = torch.tensor(0.0)
-        self.reporter = CapturingReporter()
+        self.reporter = ReporterAdapter()
 
-    def test_sampling_distribution(self):
-        graph = Graph(reporter=self.reporter)
+    def test_probabilities_and_sampling_distribution(self):
+        graph = Graph(reporter=main.Reporter)
         n1 = Neuron(zero=self.zero)
         n1.phi_v = torch.tensor(0.0)
         n2 = Neuron(zero=self.zero)
         n2.phi_v = torch.tensor(1.0)
         n3 = Neuron(zero=self.zero)
         n3.phi_v = torch.tensor(2.0)
-        graph.add_neuron('a', n1)
-        graph.add_neuron('b', n2)
-        graph.add_neuron('c', n3)
-        sampler = EntrySampler(temperature=torch.tensor(1.0), torch=torch, reporter=self.reporter)
+        graph.add_neuron("a", n1)
+        graph.add_neuron("b", n2)
+        graph.add_neuron("c", n3)
+
+        sampler = EntrySampler(
+            temperature=torch.tensor(1.0),
+            torch=torch,
+            reporter=self.reporter,
+        )
+
         probs = sampler.compute_probabilities(graph)
-        stacked = torch.stack([probs['a'], probs['b'], probs['c']])
-        self.assertTrue(torch.allclose(torch.sum(stacked), torch.tensor(1.0)))
-        chosen = sampler.sample_entry()
-        self.assertIs(chosen, n3)
-        self.assertIn(('entry_sample', 'c'), self.reporter.calls)
+        expected = torch.softmax(torch.tensor([0.0, 1.0, 2.0]), dim=0)
+        stacked = torch.stack([probs["a"], probs["b"], probs["c"]])
+        for nid, prob in probs.items():
+            main.Reporter.report(f"entry_prob_{nid}", f"Entry probability for {nid}", prob)
+        print(
+            "Probabilities:",
+            [
+                main.Reporter.report("entry_prob_a"),
+                main.Reporter.report("entry_prob_b"),
+                main.Reporter.report("entry_prob_c"),
+            ],
+        )
+        self.assertTrue(torch.allclose(stacked, expected))
+        self.assertAlmostEqual(float(stacked.sum().item()), 1.0, places=6)
+
+        counts = defaultdict(int)
+        samples = 5000
+        for _ in range(samples):
+            chosen = sampler.sample_entry()
+            counts[chosen.id] += 1
+        last_id = chosen.id
+        freq = torch.tensor(
+            [counts["a"], counts["b"], counts["c"]], dtype=torch.float32
+        ) / samples
+        print("Sampling frequencies:", freq.tolist())
+        self.assertTrue(torch.allclose(freq, expected, atol=0.02))
+
+        metric = main.Reporter.report("entry_sample")
+        print("Last sampled neuron:", metric)
+        self.assertEqual(metric, last_id)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
+

--- a/tests/test_path_cost.py
+++ b/tests/test_path_cost.py
@@ -11,10 +11,19 @@ from network.path_cost import PathCostCalculator
 
 class TestPathCost(unittest.TestCase):
     def setUp(self):
+        torch.manual_seed(0)
         main.Reporter._metrics = {}
         self.zero = torch.tensor(0.0)
-        self.neuron = Neuron(last_local_loss=torch.tensor(2.0), lambda_v=torch.tensor(3.0), zero=self.zero)
-        self.synapse = Synapse(c_e=torch.tensor(5.0), lambda_e=torch.tensor(7.0), zero=self.zero)
+        self.neuron = Neuron(
+            last_local_loss=torch.tensor(2.0),
+            lambda_v=torch.tensor(3.0),
+            zero=self.zero,
+        )
+        self.synapse = Synapse(
+            c_e=torch.tensor(5.0),
+            lambda_e=torch.tensor(7.0),
+            zero=self.zero,
+        )
         self.calc = PathCostCalculator(reporter=main.Reporter, zero=self.zero)
 
     def test_compute_cost(self):

--- a/tests/test_path_selection.py
+++ b/tests/test_path_selection.py
@@ -1,31 +1,76 @@
 import unittest
 import sys
 import pathlib
+from collections import defaultdict
+
 import torch
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
 import main
-from network.entities import Neuron, Synapse
+from network.entities import Neuron
 from network.path_selector import PathSelector
 
 
 class TestPathSelection(unittest.TestCase):
     def setUp(self):
+        torch.manual_seed(0)
         main.Reporter._metrics = {}
         self.zero = torch.tensor(0.0)
 
-    def test_minimal_loss_path(self):
+    def test_select_exact(self):
         neuron = Neuron(zero=self.zero)
-        neuron.record_local_loss(torch.tensor(2.0))
-        s1 = Synapse(lambda_e=torch.tensor(1.0), c_e=torch.tensor(0.0), zero=self.zero)
-        s2 = Synapse(lambda_e=torch.tensor(0.1), c_e=torch.tensor(0.0), zero=self.zero)
+        paths = [
+            (("p0",), torch.tensor(3.0)),
+            (("p1",), torch.tensor(1.0)),
+            (("p2",), torch.tensor(2.0)),
+        ]
         selector = PathSelector(reporter=main.Reporter)
-        state = {"outgoing_synapses": [s1, s2], "global_loss_target": self.zero}
-        chosen = selector.select_path(neuron, state)
-        print("Path selector calls:", main.Reporter.report("path_selector_calls"))
-        print("Last path score:", main.Reporter.report("path_selector_last_score"))
-        self.assertIs(chosen, s2)
+        best, sampled = selector.select_exact(neuron, paths)
+        self.assertIs(best, paths[1][0])
+        self.assertIs(sampled, paths[1][0])
+        selected_metric = main.Reporter.report(f"neuron_{id(neuron)}_selected_path")
+        sampled_cost = main.Reporter.report(f"neuron_{id(neuron)}_sampled_path_cost")
+        print("Selected index:", selected_metric)
+        print("Sampled path cost:", sampled_cost)
+        self.assertEqual(selected_metric, 1)
+        self.assertTrue(torch.allclose(sampled_cost, paths[1][1]))
+
+    def test_select_soft_distribution(self):
+        neuron = Neuron(zero=self.zero)
+        paths = [
+            (("p0",), torch.tensor(1.0)),
+            (("p1",), torch.tensor(2.0)),
+            (("p2",), torch.tensor(3.0)),
+        ]
+        selector = PathSelector(reporter=main.Reporter)
+        counts = defaultdict(int)
+        draws = 5000
+        for _ in range(draws):
+            best, sampled = selector.select_soft(
+                neuron,
+                paths,
+                R_v_star=torch.tensor(0.0),
+                T_sample=torch.tensor(1.0),
+            )
+            for idx, (seq, cost) in enumerate(paths):
+                if sampled is seq:
+                    counts[idx] += 1
+                    last_idx = idx
+                    break
+        costs = torch.tensor([c.item() for _, c in paths])
+        rewards = torch.exp((torch.tensor(0.0) - costs) / 1.0)
+        expected = rewards / rewards.sum()
+        freq = torch.tensor([counts[0], counts[1], counts[2]], dtype=torch.float32) / draws
+        print("Sampling frequencies:", freq.tolist())
+        self.assertTrue(torch.allclose(freq, expected, atol=0.02))
+        selected_metric = main.Reporter.report(f"neuron_{id(neuron)}_selected_path")
+        sampled_cost = main.Reporter.report(f"neuron_{id(neuron)}_sampled_path_cost")
+        print("Selected index:", selected_metric)
+        print("Sampled path cost:", sampled_cost)
+        self.assertEqual(selected_metric, 0)
+        self.assertTrue(torch.allclose(sampled_cost, paths[last_idx][1]))
 
 
 if __name__ == "__main__":
     unittest.main()
+


### PR DESCRIPTION
## Summary
- add entry sampler test verifying Eq. (1.1) probabilities and sampling distribution
- cover path cost components and annealing per Eq. (1.2)
- validate exact and soft path selection with reporter metrics

## Testing
- `pytest tests/test_entry_sampler.py tests/test_path_cost.py tests/test_path_selection.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c13da4a4a483278bebbbbcd7c962a9