### PR TITLE
Implement PathForwarder for loss-driven path timing

### DIFF
--- a/network/path_forwarder.py
+++ b/network/path_forwarder.py
@@ -1,0 +1,80 @@
+r"""Utilities for forwarding along a selected neuron path.
+
+The :class:`PathForwarder` traverses a sequence of neurons, updating their
+cumulative losses and recording activation timestamps.  The total traversal
+time is computed according to Eq. (2.3)::
+
+    S(P) = \\sum_{k=0}^K (s_{v_k} - s_{v_{k-1}})
+
+All timing metrics are reported through an optional reporter compatible with
+:class:`main.Reporter`.
+"""
+
+
+class PathForwarder:
+    """Execute neuron updates along a path while measuring timing information.
+
+    Parameters
+    ----------
+    reporter : object, optional
+        Object providing a ``report`` method.  Metrics are written to this
+        reporter when supplied.
+    time_source : callable, optional
+        Function returning a monotonically increasing timestamp.  Defaults to
+        :func:`time.perf_counter`.
+    """
+
+    def __init__(self, reporter=None, time_source=None):
+        self._reporter = reporter
+        if time_source is None:
+            from time import perf_counter  # local import
+            self._time_source = perf_counter
+        else:
+            self._time_source = time_source
+
+    def run(self, path, losses):
+        """Traverse ``path`` applying ``losses`` and record timing metrics.
+
+        The method iterates over ``path`` and ``losses`` simultaneously,
+        retrieving a timestamp ``t_curr`` for each hop.  For every neuron the
+        corresponding loss is forwarded via
+        :meth:`network.entities.Neuron.update_cumulative_loss` and the
+        activation is recorded with :meth:`network.entities.Neuron.record_activation`.
+        Durations between successive timestamps are accumulated to yield the
+        total path time ``S(P)``.
+
+        Parameters
+        ----------
+        path : iterable
+            Sequence of neurons to traverse.
+        losses : iterable
+            Sequence of loss tensors or numbers, one per neuron in ``path``.
+
+        Returns
+        -------
+        dict
+            Mapping containing ``path_time`` and ``final_loss`` where
+            ``final_loss`` corresponds to the cumulative loss of the last
+            neuron in ``path``.
+        """
+
+        start_time = self._time_source()
+        prev_time = start_time
+        total_time = 0.0
+        last_neuron = None
+        for neuron, loss in zip(path, losses):
+            t_curr = self._time_source()
+            neuron.update_cumulative_loss(loss)
+            neuron.record_activation(t_curr, t_curr)
+            hop_duration = t_curr - prev_time
+            total_time += hop_duration
+            prev_time = t_curr
+            last_neuron = neuron
+        final_loss = getattr(last_neuron, "cumulative_loss", 0)
+        if self._reporter is not None:
+            self._reporter.report(
+                "path_total_time",
+                "Total traversal time for processed path",
+                total_time,
+            )
+        return {"path_time": total_time, "final_loss": final_loss}

--- a/tests/test_path_forwarder.py
+++ b/tests/test_path_forwarder.py
@@ -1,0 +1,31 @@
+import unittest
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+from main import Reporter
+from network.entities import Neuron
+from network.path_forwarder import PathForwarder
+
+
+class TestPathForwarder(unittest.TestCase):
+    def test_run_updates_and_reports(self):
+        Reporter._metrics = {}
+        times = iter([0.0, 1.0, 3.0])
+
+        def fake_time():
+            return next(times)
+
+        n1 = Neuron(zero=0)
+        n2 = Neuron(zero=0)
+        forwarder = PathForwarder(reporter=Reporter, time_source=fake_time)
+        result = forwarder.run([n1, n2], [1.0, 2.0])
+        print("result", result)
+        print("metric", Reporter.report("path_total_time"))
+        self.assertEqual(result["path_time"], 3.0)
+        self.assertEqual(result["final_loss"], n2.cumulative_loss)
+        self.assertEqual(Reporter.report("path_total_time"), 3.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add PathForwarder to traverse neuron paths, applying losses and capturing hop times
- report path_total_time and expose path_time/final_loss
- cover PathForwarder behavior with unit test

## Testing
- `pytest tests/test_path_forwarder.py -q`
- `pytest tests/test_graph_forward.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1421454988327a8dbef29f806113e