### PR TITLE
Inject reporter into neuron metrics and fix loss delta

### DIFF
--- a/network/path_forwarder.py
+++ b/network/path_forwarder.py
@@ -64,8 +64,8 @@ class PathForwarder:
         last_neuron = None
         for neuron, loss in zip(path, losses):
             t_curr = self._time_source()
-            neuron.update_cumulative_loss(loss)
-            neuron.record_activation(t_curr, t_curr)
+            neuron.update_cumulative_loss(loss, self._reporter)
+            neuron.record_activation(t_curr, t_curr, self._reporter)
             hop_duration = t_curr - prev_time
             total_time += hop_duration
             prev_time = t_curr

--- a/tests/test_graph_entities.py
+++ b/tests/test_graph_entities.py
@@ -42,7 +42,7 @@ class TestGraphEntities(unittest.TestCase):
 
     def test_cumulative_loss_tracking(self):
         n = Neuron(zero=self.zero)
-        n.update_cumulative_loss(torch.tensor(1.5))
+        n.update_cumulative_loss(torch.tensor(1.5), reporter=main.Reporter)
         self.assertAlmostEqual(n.step_loss.item(), 1.5)
         self.assertAlmostEqual(n.cumulative_loss.item(), 1.5)
         step_metric = main.Reporter.report(f"neuron_{id(n)}_step_loss")
@@ -51,7 +51,7 @@ class TestGraphEntities(unittest.TestCase):
         print("Recorded cumulative loss:", cum_metric)
         self.assertAlmostEqual(step_metric.item(), 1.5)
         self.assertAlmostEqual(cum_metric.item(), 1.5)
-        n.update_cumulative_loss(torch.tensor(2.0))
+        n.update_cumulative_loss(torch.tensor(2.0), reporter=main.Reporter)
         self.assertAlmostEqual(n.step_loss.item(), 2.0)
         self.assertAlmostEqual(n.cumulative_loss.item(), 3.5)
         step_metric = main.Reporter.report(f"neuron_{id(n)}_step_loss")
@@ -70,8 +70,10 @@ class TestGraphEntities(unittest.TestCase):
 
     def test_activation_recording(self):
         n = Neuron(zero=self.zero)
-        n.update_cumulative_loss(torch.tensor(1.0))
-        n.record_activation(torch.tensor(1.0), torch.tensor(2.0))
+        n.update_cumulative_loss(torch.tensor(1.0), reporter=main.Reporter)
+        n.record_activation(
+            torch.tensor(1.0), torch.tensor(2.0), reporter=main.Reporter
+        )
         self.assertAlmostEqual(n.timestamp.item(), 1.0)
         self.assertAlmostEqual(n.measured_time.item(), 2.0)
         speed_metric = main.Reporter.report(f"neuron_{id(n)}_loss_decrease_speed")


### PR DESCRIPTION
## Summary
- decouple neurons from main module by accepting reporter instances in loss and activation updates
- track cumulative loss at last activation to compute proper loss decrease speed
- adjust path forwarder and tests for reporter injection

## Testing
- `pytest tests/test_graph_entities.py -q`
- `pytest tests/test_path_forwarder.py -q`
- `pytest tests/test_forward_pass.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c149f5c1048327b7ce41d96cfa154d