### PR TITLE
Add topology fitness evaluation

### DIFF
--- a/network/topology_fitness.py
+++ b/network/topology_fitness.py
@@ -1,0 +1,103 @@
+"""Evaluation of graph topology fitness."""
+
+
+class TopologyFitness:
+    r"""Compute fitness of network topology based on path statistics and complexity.
+
+    The fitness follows Eq. (3.2)::
+
+        F = \sum_s \sum_{P\in S} G(P) - C
+
+    where ``G(P)`` aggregates loss, latency, and cost for a path ``P`` and ``C``
+    is the global complexity of the graph. All values are expected to be tensors
+    so that gradients can propagate through the computation.
+
+    Parameters
+    ----------
+    reporter : object, optional
+        Object providing a ``report`` method for metric recording.
+    """
+
+    def __init__(self, reporter=None):
+        self._reporter = reporter
+
+    def evaluate(self, paths_stats, complexity):
+        """Return the topology fitness for ``paths_stats`` given ``complexity``.
+
+        ``paths_stats`` should map a source identifier to an iterable of path
+        statistic dictionaries. Each statistic dictionary must contain the keys
+        ``'loss'``, ``'latency'``, and ``'cost'`` whose values are tensors.
+        ``complexity`` is the scalar tensor returned by
+        :class:`network.complexity.ComplexityCalculator`.
+        """
+        zero = complexity * 0 if hasattr(complexity, "__mul__") else 0
+        total_score = zero
+        total_loss = zero
+        total_latency = zero
+        total_cost = zero
+        if hasattr(paths_stats, "items"):
+            sources = paths_stats.items()
+        else:
+            sources = enumerate(paths_stats)
+        for src_key, path_list in sources:
+            src_sum = zero
+            for p_idx, stats in enumerate(path_list):
+                loss = stats.get("loss", zero)
+                latency = stats.get("latency", zero)
+                cost = stats.get("cost", zero)
+                total_loss = total_loss + loss
+                total_latency = total_latency + latency
+                total_cost = total_cost + cost
+                path_value = -(loss + latency + cost)
+                src_sum = src_sum + path_value
+                if self._reporter is not None:
+                    self._reporter.report(
+                        f"path_{src_key}_{p_idx}_loss",
+                        "Loss contribution for path",
+                        loss,
+                    )
+                    self._reporter.report(
+                        f"path_{src_key}_{p_idx}_latency",
+                        "Latency contribution for path",
+                        latency,
+                    )
+                    self._reporter.report(
+                        f"path_{src_key}_{p_idx}_cost",
+                        "Cost contribution for path",
+                        cost,
+                    )
+                    self._reporter.report(
+                        f"path_{src_key}_{p_idx}_value",
+                        "Aggregated value for path",
+                        path_value,
+                    )
+            total_score = total_score + src_sum
+            if self._reporter is not None:
+                self._reporter.report(
+                    f"source_{src_key}_sum",
+                    "Aggregate path value for source",
+                    src_sum,
+                )
+        fitness = total_score - complexity
+        if self._reporter is not None:
+            self._reporter.report(
+                "total_path_loss",
+                "Total cumulative path loss",
+                total_loss,
+            )
+            self._reporter.report(
+                "total_path_latency",
+                "Total cumulative path latency",
+                total_latency,
+            )
+            self._reporter.report(
+                "total_path_cost",
+                "Total cumulative path cost",
+                total_cost,
+            )
+            self._reporter.report(
+                "fitness_value",
+                "Overall topology fitness",
+                fitness,
+            )
+        return fitness

--- a/tests/test_topology_fitness.py
+++ b/tests/test_topology_fitness.py
@@ -1,0 +1,58 @@
+import unittest
+import torch
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+import main
+from network.topology_fitness import TopologyFitness
+
+
+class TestTopologyFitness(unittest.TestCase):
+    def setUp(self):
+        main.Reporter._metrics = {}
+
+    def test_evaluate_topology_fitness(self):
+        paths_stats = {
+            "src1": [
+                {
+                    "loss": torch.tensor(0.5, requires_grad=True),
+                    "latency": torch.tensor(0.1, requires_grad=True),
+                    "cost": torch.tensor(0.2, requires_grad=True),
+                },
+                {
+                    "loss": torch.tensor(0.3, requires_grad=True),
+                    "latency": torch.tensor(0.2, requires_grad=True),
+                    "cost": torch.tensor(0.1, requires_grad=True),
+                },
+            ],
+            "src2": [
+                {
+                    "loss": torch.tensor(0.4, requires_grad=True),
+                    "latency": torch.tensor(0.3, requires_grad=True),
+                    "cost": torch.tensor(0.2, requires_grad=True),
+                }
+            ],
+        }
+        complexity = torch.tensor(0.6, requires_grad=True)
+        tf = TopologyFitness(main.Reporter)
+        fitness = tf.evaluate(paths_stats, complexity)
+        expected = -(
+            torch.tensor(0.5 + 0.1 + 0.2)
+            + torch.tensor(0.3 + 0.2 + 0.1)
+            + torch.tensor(0.4 + 0.3 + 0.2)
+        ) - complexity
+        self.assertTrue(torch.allclose(fitness, expected))
+        fitness.backward()
+        self.assertIsNotNone(complexity.grad)
+        self.assertIsNotNone(paths_stats["src1"][0]["loss"].grad)
+        self.assertIsNotNone(paths_stats["src1"][1]["latency"].grad)
+        self.assertIsNotNone(paths_stats["src2"][0]["cost"].grad)
+        self.assertIsNotNone(main.Reporter.report("fitness_value"))
+        self.assertIsNotNone(main.Reporter.report("total_path_loss"))
+        self.assertIsNotNone(main.Reporter.report("total_path_latency"))
+        self.assertIsNotNone(main.Reporter.report("total_path_cost"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `TopologyFitness` for graph fitness calculation with reporter metrics
- add tests validating path aggregation, reporter logging, and gradient flow

## Testing
- `pytest tests/test_topology_fitness.py tests/test_complexity_calculator.py tests/test_complexity_reporting.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c14e4762a48327881c91d283d52d4a