### PR TITLE
Add evolution operator with mutation logging and tests

### DIFF
--- a/network/evolution.py
+++ b/network/evolution.py
@@ -1,0 +1,244 @@
+"""Evolutionary operators for graph mutations.
+
+This module defines the :class:`EvolutionOperator` responsible for mutating a
+neural graph through addition, removal and relocation of neurons and synapses.
+Each mutation follows Eq. (3.3) variants and evaluates delta thresholds before
+applying changes.  Complexity and fitness values are recorded before and after
+mutations to allow detailed analysis of the evolutionary process.
+"""
+
+
+class EvolutionOperator:
+    """Perform structural mutations on a neural graph.
+
+    Parameters
+    ----------
+    graph : object
+        Graph instance providing ``add_neuron``, ``remove_neuron``,
+        ``add_synapse``, ``remove_synapse`` and related methods.
+    complexity_calculator : object
+        Instance of :class:`~network.complexity.ComplexityCalculator`.
+    fitness_evaluator : object
+        Instance of :class:`~network.topology_fitness.TopologyFitness`.
+    theta_add : object
+        Threshold :math:`\theta_{add}` for neuron insertion.
+    theta_remove : object
+        Threshold :math:`\theta_{rem}` for neuron removal.
+    theta_add_synapse : object
+        Threshold :math:`\theta_{add,e}` for synapse insertion.
+    theta_remove_synapse : object
+        Threshold :math:`\theta_{rem,e}` for synapse deletion.
+    theta_move_synapse : object
+        Threshold :math:`\theta_{move,e}` for synapse relocation.
+    reporter : object, optional
+        Metrics collector implementing ``report(name, desc, value)``.
+    """
+
+    def __init__(
+        self,
+        graph,
+        complexity_calculator,
+        fitness_evaluator,
+        theta_add,
+        theta_remove,
+        theta_add_synapse,
+        theta_remove_synapse,
+        theta_move_synapse,
+        reporter=None,
+    ):
+        self._graph = graph
+        self._complexity = complexity_calculator
+        self._fitness = fitness_evaluator
+        self._theta_add = theta_add
+        self._theta_remove = theta_remove
+        self._theta_add_synapse = theta_add_synapse
+        self._theta_remove_synapse = theta_remove_synapse
+        self._theta_move_synapse = theta_move_synapse
+        self._reporter = reporter
+
+    def _log_state(self, pre_c, pre_f, post_c, post_f):
+        if self._reporter is not None:
+            self._reporter.report(
+                "complexity_before",
+                "Global complexity prior to mutation",
+                pre_c,
+            )
+            self._reporter.report(
+                "fitness_before",
+                "Topology fitness prior to mutation",
+                pre_f,
+            )
+            self._reporter.report(
+                "complexity_after",
+                "Global complexity following mutation",
+                post_c,
+            )
+            self._reporter.report(
+                "fitness_after",
+                "Topology fitness following mutation",
+                post_f,
+            )
+
+    def _should_apply(self, delta, threshold):
+        if hasattr(delta, "__ge__"):
+            decision = delta >= threshold
+            if hasattr(decision, "item"):
+                return bool(decision.item())
+            return bool(decision)
+        return False
+
+    def add_neuron(self, neuron_ctx, paths_stats=None):
+        pre_c = self._complexity.compute(self._graph)
+        pre_f = self._fitness.evaluate(paths_stats or {}, pre_c)
+        zero = pre_c * 0 if hasattr(pre_c, "__mul__") else 0
+        b = neuron_ctx.get("b_vn", zero)
+        g = neuron_ctx.get("g_vn", zero)
+        latency = neuron_ctx.get("latency", zero)
+        cost = neuron_ctx.get("cost", zero)
+        delta = b + g - latency - cost
+        if self._reporter is not None:
+            self._reporter.report(
+                "add_neuron_delta", "Delta for neuron addition", delta
+            )
+        applied = False
+        if self._should_apply(delta, self._theta_add):
+            neuron_id = neuron_ctx.get("neuron_id")
+            neuron = neuron_ctx.get("neuron")
+            src_id = neuron_ctx.get("source_id")
+            tgt_id = neuron_ctx.get("target_id")
+            syn_in_id = neuron_ctx.get("synapse_in_id")
+            syn_in = neuron_ctx.get("synapse_in")
+            syn_out_id = neuron_ctx.get("synapse_out_id")
+            syn_out = neuron_ctx.get("synapse_out")
+            self._graph.add_neuron(neuron_id, neuron)
+            self._graph.add_synapse(syn_in_id, src_id, neuron_id, syn_in)
+            self._graph.add_synapse(syn_out_id, neuron_id, tgt_id, syn_out)
+            applied = True
+        post_c = self._complexity.compute(self._graph)
+        post_f = self._fitness.evaluate(paths_stats or {}, post_c)
+        self._log_state(pre_c, pre_f, post_c, post_f)
+        if self._reporter is not None:
+            self._reporter.report(
+                "add_neuron_applied", "Neuron addition executed", int(applied)
+            )
+        return applied
+
+    def remove_neuron(self, neuron_id, metrics, paths_stats=None):
+        pre_c = self._complexity.compute(self._graph)
+        pre_f = self._fitness.evaluate(paths_stats or {}, pre_c)
+        neuron = self._graph.get_neuron(neuron_id)
+        zero = pre_c * 0 if hasattr(pre_c, "__mul__") else 0
+        b = metrics.get("b_vn", getattr(neuron, "b_vn", zero))
+        g = metrics.get("g_vn", getattr(neuron, "g_vn", zero))
+        latency = metrics.get("latency", getattr(neuron, "lambda_v", zero))
+        cost = metrics.get("cost", getattr(neuron, "c_v", zero))
+        delta = b - g - latency - cost
+        if self._reporter is not None:
+            self._reporter.report(
+                "remove_neuron_delta", "Delta for neuron removal", delta
+            )
+        applied = False
+        if self._should_apply(delta, self._theta_remove):
+            self._graph.remove_neuron(neuron_id)
+            applied = True
+        post_c = self._complexity.compute(self._graph)
+        post_f = self._fitness.evaluate(paths_stats or {}, post_c)
+        self._log_state(pre_c, pre_f, post_c, post_f)
+        if self._reporter is not None:
+            self._reporter.report(
+                "remove_neuron_applied", "Neuron removal executed", int(applied)
+            )
+        return applied
+
+    def add_synapse(self, syn_ctx, paths_stats=None):
+        pre_c = self._complexity.compute(self._graph)
+        pre_f = self._fitness.evaluate(paths_stats or {}, pre_c)
+        zero = pre_c * 0 if hasattr(pre_c, "__mul__") else 0
+        b = syn_ctx.get("b_e", zero)
+        g = syn_ctx.get("g_e", zero)
+        latency = syn_ctx.get("latency", zero)
+        cost = syn_ctx.get("cost", zero)
+        delta = b + g - latency - cost
+        if self._reporter is not None:
+            self._reporter.report(
+                "add_synapse_delta", "Delta for synapse addition", delta
+            )
+        applied = False
+        if self._should_apply(delta, self._theta_add_synapse):
+            syn_id = syn_ctx.get("synapse_id")
+            src = syn_ctx.get("source_id")
+            tgt = syn_ctx.get("target_id")
+            syn = syn_ctx.get("synapse")
+            self._graph.add_synapse(syn_id, src, tgt, syn)
+            applied = True
+        post_c = self._complexity.compute(self._graph)
+        post_f = self._fitness.evaluate(paths_stats or {}, post_c)
+        self._log_state(pre_c, pre_f, post_c, post_f)
+        if self._reporter is not None:
+            self._reporter.report(
+                "add_synapse_applied", "Synapse addition executed", int(applied)
+            )
+        return applied
+
+    def remove_synapse(self, synapse_id, metrics, paths_stats=None):
+        pre_c = self._complexity.compute(self._graph)
+        pre_f = self._fitness.evaluate(paths_stats or {}, pre_c)
+        synapse = self._graph.get_synapse(synapse_id)
+        zero = pre_c * 0 if hasattr(pre_c, "__mul__") else 0
+        b = metrics.get("b_e", getattr(synapse, "b_e", zero))
+        g = metrics.get("g_e", getattr(synapse, "g_e", zero))
+        latency = metrics.get("latency", getattr(synapse, "lambda_e", zero))
+        cost = metrics.get("cost", getattr(synapse, "c_e", zero))
+        delta = b - g - latency - cost
+        if self._reporter is not None:
+            self._reporter.report(
+                "remove_synapse_delta", "Delta for synapse removal", delta
+            )
+        applied = False
+        if self._should_apply(delta, self._theta_remove_synapse):
+            self._graph.remove_synapse(synapse_id)
+            applied = True
+        post_c = self._complexity.compute(self._graph)
+        post_f = self._fitness.evaluate(paths_stats or {}, post_c)
+        self._log_state(pre_c, pre_f, post_c, post_f)
+        if self._reporter is not None:
+            self._reporter.report(
+                "remove_synapse_applied", "Synapse removal executed", int(applied)
+            )
+        return applied
+
+    def move_synapse(
+        self,
+        synapse_id,
+        new_source_id,
+        new_target_id,
+        metrics,
+        paths_stats=None,
+    ):
+        pre_c = self._complexity.compute(self._graph)
+        pre_f = self._fitness.evaluate(paths_stats or {}, pre_c)
+        synapse = self._graph.get_synapse(synapse_id)
+        zero = pre_c * 0 if hasattr(pre_c, "__mul__") else 0
+        b = metrics.get("b_e", getattr(synapse, "b_e", zero))
+        g = metrics.get("g_e", getattr(synapse, "g_e", zero))
+        latency = metrics.get("latency", getattr(synapse, "lambda_e", zero))
+        cost = metrics.get("cost", getattr(synapse, "c_e", zero))
+        delta = b + g - latency - cost
+        if self._reporter is not None:
+            self._reporter.report(
+                "move_synapse_delta", "Delta for synapse move", delta
+            )
+        applied = False
+        if self._should_apply(delta, self._theta_move_synapse):
+            src_old, tgt_old, syn = self._graph.synapses.get(synapse_id)
+            self._graph.remove_synapse(synapse_id)
+            self._graph.add_synapse(synapse_id, new_source_id, new_target_id, syn)
+            applied = True
+        post_c = self._complexity.compute(self._graph)
+        post_f = self._fitness.evaluate(paths_stats or {}, post_c)
+        self._log_state(pre_c, pre_f, post_c, post_f)
+        if self._reporter is not None:
+            self._reporter.report(
+                "move_synapse_applied", "Synapse move executed", int(applied)
+            )
+        return applied

--- a/tests/test_evolution_operator.py
+++ b/tests/test_evolution_operator.py
@@ -1,0 +1,152 @@
+import unittest
+import torch
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+import main
+from network.graph import Graph
+from network.entities import Neuron, Synapse
+from network.complexity import ComplexityCalculator
+from network.topology_fitness import TopologyFitness
+from network.evolution import EvolutionOperator
+
+
+class TestEvolutionOperator(unittest.TestCase):
+    def setUp(self):
+        main.Reporter._metrics = {}
+        zero = torch.tensor(0.0)
+        one = torch.tensor(1.0)
+        self.zero = zero
+        self.one = one
+        self.graph = Graph(reporter=main.Reporter)
+        n1 = Neuron(zero=zero)
+        n2 = Neuron(zero=zero)
+        self.graph.add_neuron('n1', n1)
+        self.graph.add_neuron('n2', n2)
+        s1 = Synapse(zero=zero)
+        self.graph.add_synapse('s1', 'n1', 'n2', s1)
+        weights = [torch.tensor([1.0], requires_grad=True)]
+        A = [one]
+        B = [one]
+        gamma = zero
+        lambda_ = zero
+        self.complexity = ComplexityCalculator(A, B, gamma, lambda_, weights, reporter=main.Reporter)
+        self.fitness = TopologyFitness(reporter=main.Reporter)
+        self.paths_stats = {'n1': [{'loss': zero, 'latency': zero, 'cost': zero}]}
+        self.operator = EvolutionOperator(
+            self.graph,
+            self.complexity,
+            self.fitness,
+            theta_add=torch.tensor(0.5),
+            theta_remove=torch.tensor(0.5),
+            theta_add_synapse=torch.tensor(0.5),
+            theta_remove_synapse=torch.tensor(0.5),
+            theta_move_synapse=torch.tensor(0.5),
+            reporter=main.Reporter,
+        )
+
+    def test_add_and_remove_neuron(self):
+        ctx = {
+            'neuron_id': 'n_new',
+            'neuron': Neuron(zero=self.zero),
+            'source_id': 'n1',
+            'target_id': 'n2',
+            'synapse_in_id': 's_in',
+            'synapse_in': Synapse(zero=self.zero),
+            'synapse_out_id': 's_out',
+            'synapse_out': Synapse(zero=self.zero),
+            'b_vn': torch.tensor(1.0),
+            'g_vn': torch.tensor(1.0),
+            'latency': torch.tensor(0.1),
+            'cost': torch.tensor(0.1),
+        }
+        applied = self.operator.add_neuron(ctx, self.paths_stats)
+        self.assertTrue(applied)
+        self.assertIn('n_new', self.graph.neurons)
+        self.assertEqual(len(self.graph.synapses), 3)
+        pre_c = main.Reporter.report('complexity_before')
+        post_c = main.Reporter.report('complexity_after')
+        self.assertTrue(torch.allclose(pre_c, torch.tensor(5.0)))
+        self.assertTrue(torch.allclose(post_c, torch.tensor(9.0)))
+        metrics = {
+            'b_vn': torch.tensor(2.0),
+            'g_vn': torch.tensor(0.2),
+            'latency': torch.tensor(0.1),
+            'cost': torch.tensor(0.1),
+        }
+        applied_rem = self.operator.remove_neuron('n_new', metrics, self.paths_stats)
+        self.assertTrue(applied_rem)
+        self.assertNotIn('n_new', self.graph.neurons)
+        rem_pre = main.Reporter.report('complexity_before')
+        rem_post = main.Reporter.report('complexity_after')
+        self.assertTrue(torch.allclose(rem_pre, torch.tensor(9.0)))
+        self.assertTrue(torch.allclose(rem_post, torch.tensor(5.0)))
+
+    def test_synapse_operations(self):
+        syn_ctx = {
+            'synapse_id': 's2',
+            'source_id': 'n1',
+            'target_id': 'n2',
+            'synapse': Synapse(zero=self.zero),
+            'b_e': torch.tensor(1.0),
+            'g_e': torch.tensor(1.0),
+            'latency': torch.tensor(0.1),
+            'cost': torch.tensor(0.1),
+        }
+        applied = self.operator.add_synapse(syn_ctx, self.paths_stats)
+        self.assertTrue(applied)
+        self.assertIn('s2', self.graph.synapses)
+        pre_c = main.Reporter.report('complexity_before')
+        post_c = main.Reporter.report('complexity_after')
+        self.assertTrue(torch.allclose(pre_c, torch.tensor(5.0)))
+        self.assertTrue(torch.allclose(post_c, torch.tensor(6.0)))
+        metrics = {
+            'b_e': torch.tensor(2.0),
+            'g_e': torch.tensor(0.2),
+            'latency': torch.tensor(0.1),
+            'cost': torch.tensor(0.1),
+        }
+        applied_rem = self.operator.remove_synapse('s2', metrics, self.paths_stats)
+        self.assertTrue(applied_rem)
+        self.assertNotIn('s2', self.graph.synapses)
+        rem_pre = main.Reporter.report('complexity_before')
+        rem_post = main.Reporter.report('complexity_after')
+        self.assertTrue(torch.allclose(rem_pre, torch.tensor(6.0)))
+        self.assertTrue(torch.allclose(rem_post, torch.tensor(5.0)))
+
+    def test_move_synapse(self):
+        metrics = {
+            'b_e': torch.tensor(1.0),
+            'g_e': torch.tensor(1.0),
+            'latency': torch.tensor(0.1),
+            'cost': torch.tensor(0.1),
+        }
+        applied = self.operator.move_synapse('s1', 'n2', 'n1', metrics, self.paths_stats)
+        self.assertTrue(applied)
+        src, tgt, _ = self.graph.synapses['s1']
+        self.assertEqual(src, 'n2')
+        self.assertEqual(tgt, 'n1')
+
+    def test_add_neuron_threshold(self):
+        ctx = {
+            'neuron_id': 'n_fail',
+            'neuron': Neuron(zero=self.zero),
+            'source_id': 'n1',
+            'target_id': 'n2',
+            'synapse_in_id': 's_in_f',
+            'synapse_in': Synapse(zero=self.zero),
+            'synapse_out_id': 's_out_f',
+            'synapse_out': Synapse(zero=self.zero),
+            'b_vn': torch.tensor(0.1),
+            'g_vn': torch.tensor(0.1),
+            'latency': torch.tensor(0.5),
+            'cost': torch.tensor(0.5),
+        }
+        applied = self.operator.add_neuron(ctx, self.paths_stats)
+        self.assertFalse(applied)
+        self.assertNotIn('n_fail', self.graph.neurons)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `EvolutionOperator` for adding, removing, and moving neurons/synapses with delta thresholds
- log pre/post complexity and topology fitness metrics via reporter
- add tests covering neuron and synapse mutation behavior

## Testing
- `pytest tests/test_evolution_operator.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c14f1277c48327b87c0ea0f485ced2