### PR TITLE
Handle scalar activation thresholds in graph gate adjustment

### DIFF
--- a/network/graph.py
+++ b/network/graph.py
@@ -398,6 +398,8 @@ class Graph:
                 threshold = getattr(neuron, "activation_threshold", None)
                 if threshold is None:
                     continue
+                if not hasattr(threshold, "grad") and not hasattr(threshold, "shape"):
+                    threshold = torch.as_tensor(threshold)
                 grad = getattr(threshold, "grad", None)
                 if grad is None:
                     grad = torch.zeros_like(threshold)

--- a/tests/test_graph_forward.py
+++ b/tests/test_graph_forward.py
@@ -47,6 +47,38 @@ class TestGraphForward(unittest.TestCase):
         self.assertIsNotNone(Reporter.report("path_time"))
         self.assertIsNotNone(Reporter.report("final_cumulative_loss"))
 
+    def test_forward_with_scalar_threshold(self):
+        torch.manual_seed(0)
+        zero = 0
+        n1 = Neuron(zero=zero)
+        n2 = Neuron(zero=zero)
+        n1.phi_v = torch.tensor(1.0)
+        n2.phi_v = torch.tensor(-10.0)
+        n1.last_local_loss = torch.tensor(0.1)
+        n1.lambda_v = torch.tensor(0.2)
+        n2.last_local_loss = torch.tensor(0.0)
+        n2.lambda_v = torch.tensor(0.3)
+        s1 = Synapse(zero=zero)
+        s1.c_e = torch.tensor(0.2)
+        s1.lambda_e = torch.tensor(0.4)
+        Reporter._metrics = {}
+        g = Graph(reporter=Reporter)
+        g.add_neuron("n1", n1)
+        g.add_neuron("n2", n2)
+        g.add_synapse("s1", "n1", "n2", s1)
+        result = g.forward(
+            method="exact",
+            cost_params={"lambda_0": 0, "lambda_max": 1, "alpha": 1, "beta": 1, "T_heat": 1},
+        )
+        path = result["path"]
+        self.assertEqual(path[0], n1)
+        self.assertEqual(path[1], s1)
+        self.assertEqual(path[2], n2)
+        print("Scalar threshold path_time:", result.get("path_time"))
+        print("Scalar threshold final loss:", result.get("final_cumulative_loss"))
+        self.assertIn("path_time", result)
+        self.assertIn("final_cumulative_loss", result)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- ensure gate adjustment can handle scalar `activation_threshold` values by coercing them to tensors
- add regression test verifying `Graph.forward` works with scalar thresholds

## Testing
- `pytest tests/test_graph_forward.py tests/test_routing_improvements.py tests/test_evolutionary_step.py -q -s`


------
https://chatgpt.com/codex/tasks/task_e_68c15c31cd248327b5bdf648377349e9