### PR TITLE
Fix loss delta calculation across activations

### DIFF
--- a/network/entities.py
+++ b/network/entities.py
@@ -201,6 +201,7 @@ class Neuron:
             "timestamp": self.timestamp,
             "measured_time": self.measured_time,
             "loss_decrease_speed": self.loss_decrease_speed,
+            "prev_cumulative_loss": self.prev_cumulative_loss,
             "gate": self.gate,
             "activation_threshold": self.activation_threshold,
         }


### PR DESCRIPTION
## Summary
- ensure neurons compute loss decrease speed from cumulative loss across activations
- snapshot neurons' previous cumulative loss for persistence
- test cumulative loss speed after multiple updates

## Testing
- `pytest tests/test_graph_entities.py tests/test_forward_pass.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c15e748cf48327a14f3ea208bc6dcc