### PR TITLE
Add gradient computation with regularisation

### DIFF
--- a/tests/test_backprop.py
+++ b/tests/test_backprop.py
@@ -21,14 +21,26 @@ class TestBackpropagator(unittest.TestCase):
         n2 = Neuron(zero=self.zero)
         n1.update_gate(torch.tensor(0.5))
         n2.update_gate(torch.tensor(0.6))
-        n1.last_local_loss = torch.tensor(1.0)
-        n2.last_local_loss = torch.tensor(2.0)
+        w1 = torch.tensor(1.0, requires_grad=True)
+        w2 = torch.sqrt(torch.tensor(2.0, requires_grad=True))
+        n1.update_weight(w1, reporter=Reporter)
+        n2.update_weight(w2, reporter=Reporter)
+        n1.record_local_loss(n1.weight ** 2)
+        n2.record_local_loss(n2.weight ** 2)
+        n1.update_latency(torch.tensor(0.1))
+        n2.update_latency(torch.tensor(0.2))
         s1 = Synapse(zero=self.zero)
         s2 = Synapse(zero=self.zero)
         s1.gate = torch.tensor(0.7)
         s2.gate = torch.tensor(0.8)
-        s1.c_e = torch.tensor(3.0)
-        s2.c_e = torch.tensor(4.0)
+        w3 = torch.sqrt(torch.tensor(3.0, requires_grad=True))
+        w4 = torch.sqrt(torch.tensor(4.0, requires_grad=True))
+        s1.update_weight(w3, reporter=Reporter)
+        s2.update_weight(w4, reporter=Reporter)
+        s1.update_cost(s1.weight ** 2)
+        s2.update_cost(s2.weight ** 2)
+        s1.update_latency(torch.tensor(0.3))
+        s2.update_latency(torch.tensor(0.4))
         g = Graph(reporter=Reporter)
         g.add_neuron("n1", n1)
         g.add_neuron("n2", n2)
@@ -62,6 +74,43 @@ class TestBackpropagator(unittest.TestCase):
         print("Soft routing loss:", loss)
         self.assertTrue(torch.allclose(loss, expected))
         self.assertTrue(torch.allclose(Reporter.report("sample_loss"), expected))
+
+    def test_gradient_consistency(self):
+        g, path, n1, n2, s1, s2 = self._build_graph()
+        bp = Backpropagator(reporter=Reporter)
+        gates = bp.build_active_subgraph(g, path, "soft")
+        loss = bp.compute_sample_loss(g, gates)
+        grads = bp.compute_gradients(g, gates, loss)
+
+        total_cost = loss
+        for nid, neuron in g.neurons.items():
+            gate = gates["g_v"][nid]
+            lam = neuron.lambda_v
+            w = neuron.weight
+            total_cost = total_cost + gate * lam * (torch.abs(w) + 0.5 * w.pow(2))
+        for sid, (_, _, synapse) in g.synapses.items():
+            gate = gates["g_e"][sid]
+            lam = synapse.lambda_e
+            w = synapse.weight
+            total_cost = total_cost + gate * lam * 0.5 * w.pow(2)
+
+        expected_grads = torch.autograd.grad(
+            total_cost,
+            [n1.weight, n2.weight, s1.weight, s2.weight],
+            allow_unused=True,
+        )
+        print("Computed gradients:", grads)
+        print("Expected gradients:", expected_grads)
+        self.assertTrue(torch.allclose(grads["neurons"]["n1"], expected_grads[0]))
+        self.assertTrue(torch.allclose(grads["neurons"]["n2"], expected_grads[1]))
+        self.assertTrue(torch.allclose(grads["synapses"]["s1"], expected_grads[2]))
+        self.assertTrue(torch.allclose(grads["synapses"]["s2"], expected_grads[3]))
+        self.assertIsNotNone(
+            Reporter.report(f"neuron_{id(n1)}_grad_norm")
+        )
+        self.assertIsNotNone(
+            Reporter.report(f"synapse_{id(s1)}_grad_norm")
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- implement autograd-based gradient computation with L1/L2 regularisation and gradient norm reporting
- cover gradients with a new test comparing against PyTorch autograd

## Testing
- `pytest tests/test_backprop.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c165ec7928832793759eb0a69899e9