### PR TITLE
Guard gradient computation and restore latency state

### DIFF
--- a/network/graph.py
+++ b/network/graph.py
@@ -259,19 +259,21 @@ class Graph:
                         syn_map[sid] = synapse
                     backup = self._latency_estimator.peek(nid, neuron, syn_map)
                     backups.append((neuron, syn_map, backup))
-            cost = self._path_cost.compute_cost(
-                p,
-                cost_defaults["lambda_0"],
-                cost_defaults["lambda_max"],
-                cost_defaults["alpha"],
-                cost_defaults["beta"],
-                cost_defaults["T_heat"],
-            )
-            latency = self._aggregate_latency(p)
-            evaluated.append((p, cost, latency))
-            if self._latency_estimator is not None:
-                for neuron, syn_map, backup in backups:
-                    self._latency_estimator.restore(neuron, syn_map, backup)
+            try:
+                cost = self._path_cost.compute_cost(
+                    p,
+                    cost_defaults["lambda_0"],
+                    cost_defaults["lambda_max"],
+                    cost_defaults["alpha"],
+                    cost_defaults["beta"],
+                    cost_defaults["T_heat"],
+                )
+                latency = self._aggregate_latency(p)
+                evaluated.append((p, cost, latency))
+            finally:
+                if self._latency_estimator is not None:
+                    for neuron, syn_map, backup in backups:
+                        self._latency_estimator.restore(neuron, syn_map, backup)
         sequences = [(p, c) for p, c, _ in evaluated]
         if method == "soft":
             best, sampled = self._path_selector.select_soft(


### PR DESCRIPTION
## Summary
- build sample-loss accumulator on matching device/dtype to avoid cross-device ops
- skip autograd when assembled loss has no grad_fn to return zero gradients
- ensure latency estimator state is restored even if path evaluation fails

## Testing
- `pytest -q tests/test_backprop.py::TestBackpropWorkflow::test_full_backprop_workflow tests/test_backprop.py::TestBackpropWorkflow::test_vector_local_losses tests/test_backprop.py::TestBackpropWorkflow::test_vector_synapse_costs -s`
- `pytest -q tests/test_graph_forward.py tests/test_network_graph.py -s`


------
https://chatgpt.com/codex/tasks/task_e_68c16eaf3f7c8327923fec836737dd2e