### PR TITLE
Add telemetry updater and EMA step time tracking

### DIFF
--- a/network/telemetry.py
+++ b/network/telemetry.py
@@ -1,0 +1,50 @@
+"""5. Telemetry updates and definitions
+
+After the backward pass, update stored tensors for neurons on the path (or weighted by g_v in soft routing):
+
+- Timestamps: τ_t ← t_cur (tensor clock).
+- Step times: s_t ← EMA of recent measured forward latency for t.
+- Losses: ℓ_t ← ℓ_t(y_t, y^*), L_t^cum per (2.1).
+- Speed of loss decrease: r_t per (0.1).
+
+These are all tensors retained in the model state and may feed routing costs c_t (1.2), and evolutionary scores (3.4–3.5).
+"""
+
+
+class TelemetryUpdater:
+    """Update telemetry tensors for a path of neurons."""
+
+    def __init__(self, reporter=None, time_source=None, ema_alpha=0.5):
+        self._reporter = reporter
+        if time_source is None:
+            from time import perf_counter  # local import
+            self._time_source = perf_counter
+        else:
+            self._time_source = time_source
+        self._alpha = ema_alpha
+
+    def update(self, path, losses, g_v=None):
+        """Apply telemetry updates for ``path`` using ``losses``.
+
+        Parameters
+        ----------
+        path : iterable
+            Sequence of neurons to update.
+        losses : iterable
+            Per-neuron loss tensors.
+        g_v : dict, optional
+            Optional mapping of neurons or identifiers to gate weights.
+        """
+        g_v = g_v or {}
+        final_loss = None
+        for neuron, loss in zip(path, losses):
+            t_curr = self._time_source()
+            key = neuron if neuron in g_v else getattr(neuron, "id", None)
+            weight = g_v.get(key, 1.0)
+            weighted_loss = loss * weight
+            neuron.update_cumulative_loss(weighted_loss, self._reporter)
+            neuron.record_activation(t_curr, t_curr, self._reporter)
+            latency = getattr(neuron, "lambda_v", 0) * weight
+            neuron.update_step_time(latency, self._alpha, self._reporter)
+            final_loss = getattr(neuron, "cumulative_loss", final_loss)
+        return {"final_loss": final_loss} if final_loss is not None else {}

--- a/tests/test_telemetry_updater.py
+++ b/tests/test_telemetry_updater.py
@@ -1,0 +1,73 @@
+import unittest
+import sys
+import pathlib
+import torch
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+from main import Reporter
+from network.entities import Neuron
+from network.telemetry import TelemetryUpdater
+
+
+class TestTelemetryUpdater(unittest.TestCase):
+    def setUp(self):
+        Reporter._metrics = {}
+
+    def test_hard_routing_updates(self):
+        times = iter([0.0, 1.0])
+
+        def fake_time():
+            return next(times)
+
+        n1 = Neuron(zero=torch.tensor(0.0))
+        n2 = Neuron(zero=torch.tensor(0.0))
+        n1.update_latency(torch.tensor(0.5))
+        n2.update_latency(torch.tensor(1.5))
+
+        updater = TelemetryUpdater(reporter=Reporter, time_source=fake_time, ema_alpha=0.5)
+        losses = [torch.tensor(1.0), torch.tensor(2.0)]
+        result = updater.update([n1, n2], losses)
+
+        print("Reporter metrics:", Reporter._metrics)
+        print("n1 step_time, speed:", n1.step_time, n1.loss_decrease_speed)
+        print("n2 step_time, speed:", n2.step_time, n2.loss_decrease_speed)
+        print("final_loss:", result["final_loss"])
+
+        self.assertAlmostEqual(n1.step_time.item(), 0.25)
+        self.assertAlmostEqual(n2.step_time.item(), 0.75)
+        self.assertEqual(n1.cumulative_loss.item(), 1.0)
+        self.assertEqual(n2.cumulative_loss.item(), 2.0)
+        self.assertEqual(Reporter.report(f"neuron_{id(n1)}_step_time").item(), 0.25)
+        self.assertEqual(Reporter.report(f"neuron_{id(n2)}_step_time").item(), 0.75)
+        self.assertEqual(Reporter.report(f"neuron_{id(n2)}_loss_decrease_speed").item(), 2.0)
+
+    def test_soft_routing_weighting(self):
+        times = iter([0.0, 1.0])
+
+        def fake_time():
+            return next(times)
+
+        n1 = Neuron(zero=torch.tensor(0.0))
+        n2 = Neuron(zero=torch.tensor(0.0))
+        n1.update_latency(torch.tensor(2.0))
+        n2.update_latency(torch.tensor(4.0))
+
+        updater = TelemetryUpdater(reporter=Reporter, time_source=fake_time, ema_alpha=0.5)
+        losses = [torch.tensor(2.0), torch.tensor(4.0)]
+        g_v = {n1: 0.5, n2: 0.25}
+        updater.update([n1, n2], losses, g_v=g_v)
+
+        print("Reporter metrics:", Reporter._metrics)
+        print("n1 step_time, speed:", n1.step_time, n1.loss_decrease_speed)
+        print("n2 step_time, speed:", n2.step_time, n2.loss_decrease_speed)
+
+        self.assertAlmostEqual(n1.step_time.item(), 0.5)
+        self.assertAlmostEqual(n2.step_time.item(), 0.5)
+        self.assertEqual(n1.cumulative_loss.item(), 1.0)
+        self.assertEqual(n2.cumulative_loss.item(), 1.0)
+        self.assertEqual(Reporter.report(f"neuron_{id(n1)}_loss_decrease_speed").item(), 0.0)
+        self.assertEqual(Reporter.report(f"neuron_{id(n2)}_loss_decrease_speed").item(), 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- track per-neuron step time via exponential moving average
- provide TelemetryUpdater to refresh timestamps, losses, and speed after backward pass
- cover telemetry behaviour with new unit tests

## Testing
- `python -m pytest tests/test_graph_entities.py tests/test_forward_pass.py tests/test_path_forwarder.py tests/test_latency_reporting.py tests/test_loss_tracker.py tests/test_telemetry_updater.py`


------
https://chatgpt.com/codex/tasks/task_e_68c16fd0bb58832789356dbf1867f844