### PR TITLE
Add training iteration kernel and integration test

### DIFF
--- a/network/training.py
+++ b/network/training.py
@@ -1,0 +1,120 @@
+"""Orchestrator for one training iteration on a neural graph.
+
+This module defines :class:`TrainingKernel` which coordinates the forward pass,
+backward pass and telemetry updates for a single training iteration as outlined
+in the repository documentation.  The implementation purposefully avoids any
+module level imports in order to comply with repository constraints.
+"""
+
+
+class TrainingKernel:
+    """Execute a full training iteration over a graph.
+
+    Parameters
+    ----------
+    graph : object
+        Instance of :class:`network.graph.Graph` representing the current
+        neural topology.
+    backprop : object
+        Instance of :class:`network.backprop.Backpropagator` responsible for
+        gradient computations and parameter updates.
+    telemetry : object
+        Instance of :class:`network.telemetry.TelemetryUpdater` used to refresh
+        telemetry tensors after parameter updates.
+    loss_tracker : object, optional
+        Optional :class:`network.learning.LossTracker` to maintain rolling loss
+        statistics for neurons.
+    reporter : object, optional
+        Reporter used for metric emission.
+    """
+
+    def __init__(self, graph, backprop, telemetry, loss_tracker=None, reporter=None):
+        self._graph = graph
+        self._backprop = backprop
+        self._telemetry = telemetry
+        self._loss_tracker = loss_tracker
+        self._reporter = reporter
+
+    def run_iteration(
+        self,
+        routing_mode="hard",
+        cost_params=None,
+        sample_params=None,
+        lr_v=None,
+        lr_e=None,
+        optimizer=None,
+        evolution_instructions=None,
+    ):
+        """Perform one full training iteration.
+
+        The procedure follows the eight step kernel described in the project
+        documentation.  Existing components such as :meth:`graph.forward` and
+        :class:`Backpropagator` methods are orchestrated without reimplementing
+        their internal utilities.
+
+        Parameters
+        ----------
+        routing_mode : {"hard", "soft"}, optional
+            Determines whether routing is restricted to the chosen path or
+            weighted across the entire graph.
+        cost_params : dict, optional
+            Parameters forwarded to :meth:`graph.forward` for cost calculation.
+        sample_params : dict, optional
+            Sampling parameters forwarded to :meth:`graph.forward`.
+        lr_v : object, optional
+            Learning rate for neuron weights when manual updates are used.
+        lr_e : object, optional
+            Learning rate for synapse weights when manual updates are used.
+        optimizer : object, optional
+            ``torch.optim`` compatible optimizer.  When supplied, it is used for
+            the parameter update step.
+        evolution_instructions : dict, optional
+            Optional instructions passed to :meth:`graph.forward` to invoke the
+            evolutionary operator.
+
+        Returns
+        -------
+        dict
+            Combination of the results returned by :meth:`graph.forward` along
+            with ``loss`` and ``grads`` entries produced during the backward
+            pass.
+        """
+
+        method = "soft" if routing_mode == "soft" else "exact"
+        forward_kwargs = {"method": method}
+        if cost_params is not None:
+            forward_kwargs["cost_params"] = cost_params
+        if sample_params is not None:
+            forward_kwargs["sample_params"] = sample_params
+        if evolution_instructions is not None:
+            forward_kwargs["evolution_instructions"] = evolution_instructions
+
+        forward_result = self._graph.forward(**forward_kwargs)
+        path = forward_result.get("path")
+
+        gates = self._backprop.build_active_subgraph(self._graph, path, routing_mode)
+        loss = self._backprop.compute_sample_loss(self._graph, gates)
+        active = {"graph": self._graph, "g_v": gates["g_v"], "g_e": gates["g_e"], "loss": loss}
+        grads = self._backprop.compute_gradients(active)
+        active["grads"] = grads
+        self._backprop.apply_updates(active, lr_v, lr_e, optimizer)
+
+        if path:
+            neuron_path = [path[i] for i in range(0, len(path), 2)]
+            losses = [getattr(n, "last_local_loss", 0) for n in neuron_path]
+            self._telemetry.update(neuron_path, losses, gates.get("g_v"))
+            if self._loss_tracker is not None:
+                for neuron, loss in zip(neuron_path, losses):
+                    self._loss_tracker.update_loss(neuron, [loss])
+
+        if self._reporter is not None:
+            count = self._reporter.report("training_iterations") or 0
+            self._reporter.report(
+                "training_iterations",
+                "Number of completed training iterations",
+                count + 1,
+            )
+
+        forward_result["loss"] = loss
+        forward_result["grads"] = grads
+        return forward_result

--- a/tests/test_training_kernel.py
+++ b/tests/test_training_kernel.py
@@ -1,0 +1,67 @@
+import unittest
+import sys
+import pathlib
+import torch
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+from main import Reporter
+from network.entities import Neuron, Synapse
+from network.graph import Graph
+from network.backprop import Backpropagator
+from network.telemetry import TelemetryUpdater
+from network.training import TrainingKernel
+
+
+class TestTrainingKernel(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(0)
+        Reporter._metrics = {}
+        self.zero = torch.tensor(0.0)
+
+    def _build_graph(self):
+        n1 = Neuron(zero=self.zero)
+        n2 = Neuron(zero=self.zero)
+        s = Synapse(zero=self.zero)
+        n1.update_gate(torch.tensor(1.0))
+        n2.update_gate(torch.tensor(1.0))
+        s.gate = torch.tensor(1.0)
+        n1.phi_v = torch.tensor(1.0)
+        n2.phi_v = torch.tensor(-10.0)
+        w1 = torch.tensor(1.0, requires_grad=True)
+        w2 = torch.tensor(1.5, requires_grad=True)
+        w3 = torch.tensor(2.0, requires_grad=True)
+        n1.update_weight(w1, reporter=Reporter)
+        n2.update_weight(w2, reporter=Reporter)
+        s.update_weight(w3, reporter=Reporter)
+        n1.record_local_loss(n1.weight ** 2)
+        n2.record_local_loss(n2.weight ** 2)
+        s.update_cost(s.weight ** 2)
+        g = Graph(reporter=Reporter)
+        g.add_neuron("n1", n1)
+        g.add_neuron("n2", n2)
+        g.add_synapse("s", "n1", "n2", s)
+        return g, n1, n2, s
+
+    def test_iteration_updates_weights_and_metrics(self):
+        g, n1, n2, s = self._build_graph()
+        bp = Backpropagator(reporter=Reporter)
+        telemetry = TelemetryUpdater(reporter=Reporter)
+        trainer = TrainingKernel(g, bp, telemetry, reporter=Reporter)
+        lr_v = torch.tensor(0.05)
+        lr_e = torch.tensor(0.07)
+        evolution = {"remove_neuron": ("n2", {"b_vn": torch.tensor(0.0), "g_vn": torch.tensor(0.0), "latency": torch.tensor(0.0), "cost": torch.tensor(0.0)})}
+        print("Initial weights:", n1.weight, n2.weight, s.weight)
+        result = trainer.run_iteration(lr_v=lr_v, lr_e=lr_e, evolution_instructions=evolution)
+        print("Updated weights:", n1.weight, n2.weight, s.weight)
+        print("Mutation results:", result.get("mutations"))
+        self.assertIn("path", result)
+        self.assertIn("loss", result)
+        self.assertIn("grads", result)
+        self.assertNotEqual(n1.weight.item(), 1.0)
+        self.assertNotEqual(n2.weight.item(), 1.5)
+        self.assertIsNotNone(Reporter.report(f"neuron_{id(n1)}_cumulative_loss"))
+        self.assertEqual(Reporter.report("training_iterations"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `TrainingKernel` to orchestrate forward, backward, mutation and telemetry steps for one training iteration
- cover training workflow with new `test_training_kernel`

## Testing
- `pytest tests/test_training_kernel.py tests/test_graph_forward.py::TestGraphForward::test_forward_pipeline tests/test_backprop.py::TestBackpropWorkflow::test_full_backprop_workflow -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1773a40e88327afe67867c73509f7