### PR TITLE
Enable sample-aware loss and cost in graph traversal

### DIFF
--- a/network/training.py
+++ b/network/training.py
@@ -37,6 +37,7 @@ class TrainingKernel:
 
     def run_iteration(
         self,
+        sample=None,
         routing_mode="hard",
         cost_params=None,
         sample_params=None,
@@ -54,6 +55,8 @@ class TrainingKernel:
 
         Parameters
         ----------
+        sample : object, optional
+            Training sample forwarded through :meth:`graph.forward`.
         routing_mode : {"hard", "soft"}, optional
             Determines whether routing is restricted to the chosen path or
             weighted across the entire graph.
@@ -82,6 +85,8 @@ class TrainingKernel:
 
         method = "soft" if routing_mode == "soft" else "exact"
         forward_kwargs = {"method": method}
+        if sample is not None:
+            forward_kwargs["sample"] = sample
         if cost_params is not None:
             forward_kwargs["cost_params"] = cost_params
         if sample_params is not None:


### PR DESCRIPTION
## Summary
- allow Neuron and Synapse to compute per-sample loss/cost via callable hooks
- propagate a training sample through Graph.forward and TrainingKernel.run_iteration
- test sample-based loss and cost handling in forward pass and training kernel

## Testing
- `pytest tests/test_graph_forward.py::TestGraphForward::test_forward_pipeline tests/test_graph_forward.py::TestGraphForward::test_forward_with_scalar_threshold tests/test_graph_forward.py::TestGraphForward::test_forward_uses_weights tests/test_graph_forward.py::TestGraphForward::test_forward_computes_sample_losses_and_costs -q`
- `pytest tests/test_training_kernel.py::TestTrainingKernel::test_iteration_updates_weights_and_metrics tests/test_training_kernel.py::TestTrainingKernel::test_iteration_uses_sample_for_losses -q`


------
https://chatgpt.com/codex/tasks/task_e_68c183ca2f108327bc4a17be1ef2d2d3